### PR TITLE
payload: add Label to PullRequestPayload

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -2940,6 +2940,13 @@ type PullRequestPayload struct {
 		Deletions      int64     `json:"deletions"`
 		ChangedFiles   int64     `json:"changed_files"`
 	} `json:"pull_request"`
+	Label struct {
+		ID      int64  `json:"id"`
+		URL     string `json:"url"`
+		Name    string `json:"name"`
+		Color   string `json:"color"`
+		Default bool   `json:"default"`
+	} `json:"label"`
 	Repository struct {
 		ID       int64  `json:"id"`
 		Name     string `json:"name"`


### PR DESCRIPTION
Label now appears to be part of the pull request payload when the action is `labeled`, with a structure like this:

```json
  "label": {
    "id": 123456789,
    "url": "https://api.github.com/repos/samuelkarp/my-repo/labels/my-label",
    "name": "my-label",
    "color": "e6e6e6",
    "default": false
  },
```