### PR TITLE
[GitLab] Fix type of SourceProjectID in MergeRequest struct

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -312,7 +312,7 @@ type MergeRequest struct {
 	ID              int64      `json:"id"`
 	TargetBranch    string     `json:"target_branch"`
 	SourceBranch    string     `json:"source_branch"`
-	SourceProjectID string     `json:"source_project_id"`
+	SourceProjectID int64      `json:"source_project_id"`
 	AssigneeID      int64      `json:"assignee_id"`
 	AuthorID        int64      `json:"author_id"`
 	Title           string     `json:"title"`


### PR DESCRIPTION
It should be an int64, but was a string.
https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-merge-request

The incorrect type caused the MergeRequest field in comment event payloads to be empty.
