### PR TITLE
[GitLab] Add support for confidential issues

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -26,14 +26,15 @@ type Event string
 
 // GitLab hook types
 const (
-	PushEvents         Event = "Push Hook"
-	TagEvents          Event = "Tag Push Hook"
-	IssuesEvents       Event = "Issue Hook"
-	CommentEvents      Event = "Note Hook"
-	MergeRequestEvents Event = "Merge Request Hook"
-	WikiPageEvents     Event = "Wiki Page Hook"
-	PipelineEvents     Event = "Pipeline Hook"
-	BuildEvents        Event = "Build Hook"
+	PushEvents               Event = "Push Hook"
+	TagEvents                Event = "Tag Push Hook"
+	IssuesEvents             Event = "Issue Hook"
+	ConfidentialIssuesEvents Event = "Confidential Issue Hook"
+	CommentEvents            Event = "Note Hook"
+	MergeRequestEvents       Event = "Merge Request Hook"
+	WikiPageEvents           Event = "Wiki Page Hook"
+	PipelineEvents           Event = "Pipeline Hook"
+	BuildEvents              Event = "Build Hook"
 )
 
 // New creates and returns a WebHook instance denoted by the Provider type
@@ -112,6 +113,9 @@ func (hook Webhook) ParsePayload(w http.ResponseWriter, r *http.Request) {
 		json.Unmarshal([]byte(payload), &te)
 		hook.runProcessPayloadFunc(fn, te, hd)
 
+	case ConfidentialIssuesEvents:
+		// Confidential issues have the same payload as normal issues.
+		fallthrough
 	case IssuesEvents:
 		var ie IssueEventPayload
 		json.Unmarshal([]byte(payload), &ie)

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -114,8 +114,10 @@ func (hook Webhook) ParsePayload(w http.ResponseWriter, r *http.Request) {
 		hook.runProcessPayloadFunc(fn, te, hd)
 
 	case ConfidentialIssuesEvents:
-		// Confidential issues have the same payload as normal issues.
-		fallthrough
+		var cie ConfidentialIssueEventPayload
+		json.Unmarshal([]byte(payload), &cie)
+		hook.runProcessPayloadFunc(fn, cie, hd)
+
 	case IssuesEvents:
 		var ie IssueEventPayload
 		json.Unmarshal([]byte(payload), &ie)

--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -40,6 +40,13 @@ type IssueEventPayload struct {
 	Assignee         Assignee         `json:"assignee"`
 }
 
+// ConfidentialIssueEventPayload contains the information for GitLab's confidential issue event
+type ConfidentialIssueEventPayload struct {
+	// The data for confidential issues is currently the same as normal issues,
+	// so we can just embed the normal issue payload type here.
+	IssueEventPayload
+}
+
 // MergeRequestEventPayload contains the information for GitLab's merge request event
 type MergeRequestEventPayload struct {
 	ObjectKind       string           `json:"object_kind"`


### PR DESCRIPTION
Confidential issues have the same payload as normal issues, but they have a separate hook type. This pull request adds support for the `Confidential Issue Hook` event type.