### PR TITLE
Add RequestedReviewers to PullRequestPayload

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -2759,20 +2759,39 @@ type PullRequestPayload struct {
 			Type              string `json:"type"`
 			SiteAdmin         bool   `json:"site_admin"`
 		} `json:"user"`
-		Body              string     `json:"body"`
-		CreatedAt         time.Time  `json:"created_at"`
-		UpdatedAt         time.Time  `json:"updated_at"`
-		ClosedAt          *time.Time `json:"closed_at"`
-		MergedAt          *time.Time `json:"merged_at"`
-		MergeCommitSha    *string    `json:"merge_commit_sha"`
-		Assignee          *Assignee  `json:"assignee"`
-		Milestone         *Milestone `json:"milestone"`
-		CommitsURL        string     `json:"commits_url"`
-		ReviewCommentsURL string     `json:"review_comments_url"`
-		ReviewCommentURL  string     `json:"review_comment_url"`
-		CommentsURL       string     `json:"comments_url"`
-		StatusesURL       string     `json:"statuses_url"`
-		Head              struct {
+		Body               string     `json:"body"`
+		CreatedAt          time.Time  `json:"created_at"`
+		UpdatedAt          time.Time  `json:"updated_at"`
+		ClosedAt           *time.Time `json:"closed_at"`
+		MergedAt           *time.Time `json:"merged_at"`
+		MergeCommitSha     *string    `json:"merge_commit_sha"`
+		Assignee           *Assignee  `json:"assignee"`
+		Milestone          *Milestone `json:"milestone"`
+		CommitsURL         string     `json:"commits_url"`
+		ReviewCommentsURL  string     `json:"review_comments_url"`
+		ReviewCommentURL   string     `json:"review_comment_url"`
+		CommentsURL        string     `json:"comments_url"`
+		StatusesURL        string     `json:"statuses_url"`
+		RequestedReviewers []struct {
+			Login             string `json:"login"`
+			ID                int    `json:"id"`
+			AvatarURL         string `json:"avatar_url"`
+			GravatarID        string `json:"gravatar_id"`
+			URL               string `json:"url"`
+			HTMLURL           string `json:"html_url"`
+			FollowersURL      string `json:"followers_url"`
+			FollowingURL      string `json:"following_url"`
+			GistsURL          string `json:"gists_url"`
+			StarredURL        string `json:"starred_url"`
+			SubscriptionsURL  string `json:"subscriptions_url"`
+			OrganizationsURL  string `json:"organizations_url"`
+			ReposURL          string `json:"repos_url"`
+			EventsURL         string `json:"events_url"`
+			ReceivedEventsURL string `json:"received_events_url"`
+			Type              string `json:"type"`
+			SiteAdmin         bool   `json:"site_admin"`
+		} `json:"requested_reviewers,omitempty"`
+		Head struct {
 			Label string `json:"label"`
 			Ref   string `json:"ref"`
 			Sha   string `json:"sha"`


### PR DESCRIPTION
This PR adds support for the optional `requested_reviewers` attribute for the `review_requested` action as part of the`pull_request` event. This is useful for consuming which Github users have been added to a pull request.

`request_reviewers`:
```
{
  "requested_reviewers": [
      {
        "login": "foo",
        "id": 123,
        "avatar_url": "https://avatars2.githubusercontent.com/",
        "gravatar_id": "",
        "url": "https://api.github.com/users/foo",
        "html_url": "https://github.com/foo",
        "followers_url": "https://api.github.com/users/foo/followers",
        "following_url": "https://api.github.com/users/foo/following{/other_user}",
        "gists_url": "https://api.github.com/users/foo/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/foo/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/foo/subscriptions",
        "organizations_url": "https://api.github.com/users/foo/orgs",
        "repos_url": "https://api.github.com/users/foo/repos",
        "events_url": "https://api.github.com/users/foo/events{/privacy}",
        "received_events_url": "https://api.github.com/users/foo/received_events",
        "type": "User",
        "site_admin": false
      }
    ]
}
```

Thanks, let me know if you need anything else!