### PR TITLE
Make Logger interface more flexible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - mkdir -p $GOPATH/src/gopkg.in
   - ln -s $GOPATH/src/github.com/$TRAVIS_REPO_SLUG $GOPATH/src/gopkg.in/webhooks.v2
   - ln -s $GOPATH/src/github.com/$TRAVIS_REPO_SLUG $GOPATH/src/gopkg.in/webhooks.v3
+  - ln -s $GOPATH/src/github.com/$TRAVIS_REPO_SLUG $GOPATH/src/gopkg.in/webhooks.v4
 
 before_script:
   - go vet ./...

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Library webhooks
 [![Build Status](https://travis-ci.org/go-playground/webhooks.svg?branch=v3)](https://travis-ci.org/go-playground/webhooks)
 [![Coverage Status](https://coveralls.io/repos/go-playground/webhooks/badge.svg?branch=v3&service=github)](https://coveralls.io/github/go-playground/webhooks?branch=v3)
 [![Go Report Card](https://goreportcard.com/badge/go-playground/webhooks)](https://goreportcard.com/report/go-playground/webhooks)
-[![GoDoc](https://godoc.org/gopkg.in/go-playground/webhooks.v3?status.svg)](https://godoc.org/gopkg.in/go-playground/webhooks.v3)
+[![GoDoc](https://godoc.org/gopkg.in/go-playground/webhooks.v4?status.svg)](https://godoc.org/gopkg.in/go-playground/webhooks.v4)
 ![License](https://img.shields.io/dub/l/vibe-d.svg)
 
 Library webhooks allows for easy receiving and parsing of GitHub, Bitbucket and GitLab Webhook Events
@@ -24,17 +24,17 @@ Installation
 Use go get.
 
 ```shell
-go get -u gopkg.in/go-playground/webhooks.v3
+go get -u gopkg.in/go-playground/webhooks.v4
 ```
 
 Then import the package into your own code.
 
-	import "gopkg.in/go-playground/webhooks.v3"
+	import "gopkg.in/go-playground/webhooks.v4"
 
 Usage and Documentation
 ------
 
-Please see http://godoc.org/gopkg.in/go-playground/webhooks.v3 for detailed usage docs.
+Please see http://godoc.org/gopkg.in/go-playground/webhooks.v4 for detailed usage docs.
 
 ##### Examples:
 
@@ -46,8 +46,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/go-playground/webhooks.v3"
-	"gopkg.in/go-playground/webhooks.v3/github"
+	"gopkg.in/go-playground/webhooks.v4"
+	"gopkg.in/go-playground/webhooks.v4/github"
 )
 
 const (
@@ -103,8 +103,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/go-playground/webhooks.v3"
-	"gopkg.in/go-playground/webhooks.v3/github"
+	"gopkg.in/go-playground/webhooks.v4"
+	"gopkg.in/go-playground/webhooks.v4/github"
 )
 
 const (

--- a/bitbucket/bitbucket.go
+++ b/bitbucket/bitbucket.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"gopkg.in/go-playground/webhooks.v3"
+	"gopkg.in/go-playground/webhooks.v4"
 )
 
 // Webhook instance contains all methods needed to process events

--- a/bitbucket/bitbucket_test.go
+++ b/bitbucket/bitbucket_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	. "gopkg.in/go-playground/assert.v1"
-	"gopkg.in/go-playground/webhooks.v3"
+	"gopkg.in/go-playground/webhooks.v4"
 )
 
 // NOTES:

--- a/examples/custom-logger/main.go
+++ b/examples/custom-logger/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strconv"
 
-	"gopkg.in/go-playground/webhooks.v3"
-	"gopkg.in/go-playground/webhooks.v3/github"
+	"gopkg.in/go-playground/webhooks.v4"
+	"gopkg.in/go-playground/webhooks.v4/github"
 )
 
 const (
@@ -18,15 +18,15 @@ type myLogger struct {
 	PrintDebugs bool
 }
 
-func (l *myLogger) Info(msg string) {
+func (l *myLogger) Info(msg ...interface{}) {
 	log.Println(msg)
 }
 
-func (l *myLogger) Error(msg string) {
+func (l *myLogger) Error(msg ...interface{}) {
 	log.Println(msg)
 }
 
-func (l *myLogger) Debug(msg string) {
+func (l *myLogger) Debug(msg ...interface{}) {
 	if !l.PrintDebugs {
 		return
 	}

--- a/examples/multiple-handlers/main.go
+++ b/examples/multiple-handlers/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/go-playground/webhooks.v3"
-	"gopkg.in/go-playground/webhooks.v3/github"
+	"gopkg.in/go-playground/webhooks.v4"
+	"gopkg.in/go-playground/webhooks.v4/github"
 )
 
 const (

--- a/examples/single-handler/main.go
+++ b/examples/single-handler/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/go-playground/webhooks.v3"
-	"gopkg.in/go-playground/webhooks.v3/github"
+	"gopkg.in/go-playground/webhooks.v4"
+	"gopkg.in/go-playground/webhooks.v4/github"
 )
 
 const (

--- a/github/github.go
+++ b/github/github.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"gopkg.in/go-playground/webhooks.v3"
+	"gopkg.in/go-playground/webhooks.v4"
 )
 
 // Webhook instance contains all methods needed to process events

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	. "gopkg.in/go-playground/assert.v1"
-	"gopkg.in/go-playground/webhooks.v3"
+	"gopkg.in/go-playground/webhooks.v4"
 )
 
 // NOTES:

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"gopkg.in/go-playground/webhooks.v3"
+	"gopkg.in/go-playground/webhooks.v4"
 )
 
 // Webhook instance contains all methods needed to process events

--- a/gitlab/gitlab_test.go
+++ b/gitlab/gitlab_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	. "gopkg.in/go-playground/assert.v1"
-	"gopkg.in/go-playground/webhooks.v3"
+	"gopkg.in/go-playground/webhooks.v4"
 )
 
 // NOTES:
@@ -945,7 +945,7 @@ func TestMergeRequestEvent(t *testing.T) {
         }]
       }
     }
-  }  
+  }
 `
 
 	req, err := http.NewRequest("POST", "http://127.0.0.1:3011/webhooks", bytes.NewBuffer([]byte(payload)))

--- a/gogs/gogs.go
+++ b/gogs/gogs.go
@@ -10,7 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	client "github.com/gogits/go-gogs-client"
-	"gopkg.in/go-playground/webhooks.v3"
+	"gopkg.in/go-playground/webhooks.v4"
 )
 
 // Webhook instance contains all methods needed to process events

--- a/logger.go
+++ b/logger.go
@@ -9,11 +9,11 @@ var DefaultLog Logger = new(logger)
 // Logger allows for customizable logging
 type Logger interface {
 	// Info prints basic information.
-	Info(string)
+	Info(...interface{})
 	// Error prints error information.
-	Error(string)
+	Error(...interface{})
 	// Debug prints information usefull for debugging.
-	Debug(string)
+	Debug(...interface{})
 }
 
 // NewLogger returns a new logger for use.
@@ -26,17 +26,17 @@ type logger struct {
 }
 
 // Info prints basic information.
-func (l *logger) Info(msg string) {
+func (l *logger) Info(msg ...interface{}) {
 	log.Println("INFO:", msg)
 }
 
 // v prints error information.
-func (l *logger) Error(msg string) {
+func (l *logger) Error(msg ...interface{}) {
 	log.Println("ERROR:", msg)
 }
 
 // Debug prints information usefull for debugging.
-func (l *logger) Debug(msg string) {
+func (l *logger) Debug(msg ...interface{}) {
 	if !l.PrintDebugs {
 		return
 	}


### PR DESCRIPTION
Closes #31 

Changes the Logger interface to accept `...interface{}` as an argument. 
This makes it easy to swap out the `DefaultLog` with other libraries such as Logrus.

I'm not sure if I can create a branch for v4 so I just left the base fork as v3. This is my first time committing a breaking change to a gopkg.in project so I'm not sure if there's anything else I need to do.

