### PR TITLE
Deployment Payload fields should be of type string.

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -381,8 +381,7 @@ type DeploymentPayload struct {
 		Sha     string `json:"sha"`
 		Ref     string `json:"ref"`
 		Task    string `json:"task"`
-		Payload struct {
-		} `json:"payload"`
+		Payload string `json:"payload"`
 		Environment string  `json:"environment"`
 		Description *string `json:"description"`
 		Creator     struct {
@@ -555,8 +554,7 @@ type DeploymentStatusPayload struct {
 		Sha     string `json:"sha"`
 		Ref     string `json:"ref"`
 		Task    string `json:"task"`
-		Payload struct {
-		} `json:"payload"`
+		Payload string `json:"payload"`
 		Environment string  `json:"environment"`
 		Description *string `json:"description"`
 		Creator     struct {


### PR DESCRIPTION
I wanted to use the Deployment object's `Payload` field but it was an empty struct. It should be a string, as per the following snippet of an actual webhook delivery from Github:

```
{
  "deployment": {
    "url": "https://api.github.com/repos/<redacted>",
    "id": 91231524,
    "node_id": "MDEwOkRlcGyveW12bnr5MjMzNDUyNA==",
    "sha": "9ece132423201xcd8fefbf54e42d78e6f2c3d705",
    "ref": "9ece132423201xcd8fefbf54e42d78e6f2c3d705",
    "task": "deploy",
    "payload": "{\"branch\":\"throwaway_june18_2018\",\"prNumber\":226,\"prUrl\":\"https://api.github.com/repos/<redacted>\"}",
    "environment": "staging",
    "description": "Deploying <redacted>",
    "creator": {
    ...
```

I've been using this fork successfully for a week and the deployments have been fine.