### PR TITLE
Add Assignees struct to IssuesPayload as well

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -1412,6 +1412,7 @@ type IssuesPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
+	Assignee *Assignee `json:"assignee"`
 }
 
 // LabelPayload contains the information for GitHub's label hook event
@@ -3171,6 +3172,7 @@ type PullRequestPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
+	Assignee     *Assignee `json:"assignee"`
 	Installation struct {
 		ID int64 `json:"id"`
 	} `json:"installation"`

--- a/github/payload.go
+++ b/github/payload.go
@@ -1109,15 +1109,16 @@ type IssueCommentPayload struct {
 			Name  string `json:"name"`
 			Color string `json:"color"`
 		} `json:"labels"`
-		State     string     `json:"state"`
-		Locked    bool       `json:"locked"`
-		Assignee  *Assignee  `json:"assignee"`
-		Milestone *Milestone `json:"milestone"`
-		Comments  int64      `json:"comments"`
-		CreatedAt time.Time  `json:"created_at"`
-		UpdatedAt time.Time  `json:"updated_at"`
-		ClosedAt  *time.Time `json:"closed_at"`
-		Body      string     `json:"body"`
+		State     string      `json:"state"`
+		Locked    bool        `json:"locked"`
+		Assignee  *Assignee   `json:"assignee"`
+		Assignees []*Assignee `json:"assignees"`
+		Milestone *Milestone  `json:"milestone"`
+		Comments  int64       `json:"comments"`
+		CreatedAt time.Time   `json:"created_at"`
+		UpdatedAt time.Time   `json:"updated_at"`
+		ClosedAt  *time.Time  `json:"closed_at"`
+		Body      string      `json:"body"`
 	} `json:"issue"`
 	Comment struct {
 		URL      string `json:"url"`
@@ -1294,15 +1295,16 @@ type IssuesPayload struct {
 			Color   string `json:"color"`
 			Default bool   `json:"default"`
 		} `json:"labels"`
-		State     string     `json:"state"`
-		Locked    bool       `json:"locked"`
-		Assignee  *Assignee  `json:"assignee"`
-		Milestone *Milestone `json:"milestone"`
-		Comments  int64      `json:"comments"`
-		CreatedAt time.Time  `json:"created_at"`
-		UpdatedAt time.Time  `json:"updated_at"`
-		ClosedAt  *time.Time `json:"closed_at"`
-		Body      string     `json:"body"`
+		State     string      `json:"state"`
+		Locked    bool        `json:"locked"`
+		Assignee  *Assignee   `json:"assignee"`
+		Assignees []*Assignee `json:"assignees"`
+		Milestone *Milestone  `json:"milestone"`
+		Comments  int64       `json:"comments"`
+		CreatedAt time.Time   `json:"created_at"`
+		UpdatedAt time.Time   `json:"updated_at"`
+		ClosedAt  *time.Time  `json:"closed_at"`
+		Body      string      `json:"body"`
 	} `json:"issue"`
 	Repository struct {
 		ID       int64  `json:"id"`


### PR DESCRIPTION
As done in #51 for PR's. Sorry about not spotting this as well.

This also adds a singular 'Assignee' field to PR and Issue payloads. This is present when the action for a PR or Issue is "assigned" or "unassigned", detailing the user assigned or unassigned.