### PR TITLE
[Gitlab] - Add partial system hook parsing

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -89,7 +89,7 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 		return nil, ErrInvalidHTTPMethod
 	}
 
-	// Add SystemHookEvents to event slice to allow parsing of it
+	// Add SystemHookEvents to event slice to allow parsing
 	events = append(events, SystemHookEvents)
 
 	// If we have a Secret set, we should check the MAC
@@ -107,7 +107,6 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 
 	gitLabEvent := Event(event)
 
-	// check if payload is empty - that means it was no system hook call
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil || len(payload) == 0 {
 		return nil, ErrParsingPayload

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -89,9 +89,6 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 		return nil, ErrInvalidHTTPMethod
 	}
 
-	// Add SystemHookEvents to event slice to allow parsing
-	events = append(events, SystemHookEvents)
-
 	// If we have a Secret set, we should check the MAC
 	if len(hook.secret) > 0 {
 		signature := r.Header.Get("X-Gitlab-Token")

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -82,6 +82,9 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 		_ = r.Body.Close()
 	}()
 
+	var err error
+	var payload []byte
+
 	if len(events) == 0 {
 		return nil, ErrEventNotSpecifiedToParse
 	}
@@ -95,15 +98,13 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 	}
 
 	gitLabEvent := Event(event)
-	payload := []byte{}
 
 	if gitLabEvent == SystemHooks {
 
-		sysPayload, err := ioutil.ReadAll(r.Body)
-		if err != nil || len(sysPayload) == 0 {
+		payload, err = ioutil.ReadAll(r.Body)
+		if err != nil || len(payload) == 0 {
 			return nil, ErrParsingSystemPayload
 		}
-		payload = sysPayload
 
 		var sysPl SystemHookPayload
 		err = json.Unmarshal([]byte(payload), &sysPl)
@@ -135,7 +136,7 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 
 	// check if payload is empty - that means it was no system hook call
 	if len(payload) == 0 {
-		payload, err := ioutil.ReadAll(r.Body)
+		payload, err = ioutil.ReadAll(r.Body)
 		if err != nil || len(payload) == 0 {
 			return nil, ErrParsingPayload
 		}
@@ -152,47 +153,47 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 	switch gitLabEvent {
 	case PushEvents:
 		var pl PushEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case TagEvents:
 		var pl TagEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case ConfidentialIssuesEvents:
 		var pl ConfidentialIssueEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case IssuesEvents:
 		var pl IssueEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case CommentEvents:
 		var pl CommentEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case MergeRequestEvents:
 		var pl MergeRequestEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case WikiPageEvents:
 		var pl WikiPageEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case PipelineEvents:
 		var pl PipelineEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 
 	case BuildEvents:
 		var pl BuildEventPayload
-		err := json.Unmarshal([]byte(payload), &pl)
+		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 	default:
 		return nil, fmt.Errorf("unknown event %s", gitLabEvent)

--- a/gitlab/gitlab_test.go
+++ b/gitlab/gitlab_test.go
@@ -306,7 +306,7 @@ func TestSystemHooks(t *testing.T) {
 			var parseError error
 			var results interface{}
 			server := newServer(func(w http.ResponseWriter, r *http.Request) {
-				results, parseError = hook.Parse(r, tc.event)
+				results, parseError = hook.Parse(r, SystemHookEvents, tc.event)
 			})
 			defer server.Close()
 			req, err := http.NewRequest(http.MethodPost, server.URL+path, payload)

--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -148,6 +148,11 @@ type BuildEventPayload struct {
 	Repository        Repository  `json:"repository"`
 }
 
+// SystemHookPayload contains the ObjectKind to match with real hook events
+type SystemHookPayload struct {
+	ObjectKind string `json:"object_kind"`
+}
+
 // Issue contains all of the GitLab issue information
 type Issue struct {
 	ID          int64      `json:"id"`


### PR DESCRIPTION
In Gitlab it is possible to setup system hooks for specific events like push, tag push, merge request unfortunately the current implementation uses the `X-Gitlab-Event` rather the `object_kind` property from the payload itself so the webhook won't listen on them.

I have added the 3 mainly used system hook calls by parsing the payload and use the `object_kind` property to overwrite the gitLabEvent variable and parse the payload as what it really is.

I'd rather see this as an MVP to be able to use those 3 events for custom integration of the webhook,  but i think it would be better to omit the check of `X-Gitlab-Event` and use the `object_kind` of the payload itself, If this is okay for you i will try to offer you a new PR in the future with those changes.

Also feedback on the code is highly appreciated as i am "relatively" new in writing production ready go.