### PR TITLE
[Github] Add installation_repositories event

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -36,6 +36,7 @@ const (
 	ForkEvent                     Event = "fork"
 	GollumEvent                   Event = "gollum"
 	InstallationEvent             Event = "installation"
+	InstallationRepositoriesEvent Event = "installation_repositories"
 	IntegrationInstallationEvent  Event = "integration_installation"
 	IssueCommentEvent             Event = "issue_comment"
 	IssuesEvent                   Event = "issues"
@@ -191,6 +192,10 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 		return pl, err
 	case InstallationEvent, IntegrationInstallationEvent:
 		var pl InstallationPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case InstallationRepositoriesEvent:
+		var pl InstallationRepositoriesPayload
 		err = json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 	case IssueCommentEvent:

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -214,6 +214,16 @@ func TestWebhooks(t *testing.T) {
 			},
 		},
 		{
+			name:     "InstallationRepositoriesEvent",
+			event:    InstallationRepositoriesEvent,
+			typ:      InstallationRepositoriesPayload{},
+			filename: "../testdata/github/installation-repositories.json",
+			headers: http.Header{
+				"X-Github-Event":  []string{"installation_repositories"},
+				"X-Hub-Signature": []string{"sha1=c587fbd9dd169db8ae592b3bcc80b08e2e6f4f45"},
+			},
+		},
+		{
 			name:     "IntegrationInstallationEvent",
 			event:    IntegrationInstallationEvent,
 			typ:      InstallationPayload{},

--- a/github/payload.go
+++ b/github/payload.go
@@ -1073,6 +1073,86 @@ type InstallationPayload struct {
 	} `json:"sender"`
 }
 
+// InstallationRepositoriesPayload contains the information for GitHub's installation_repositories hook events
+type InstallationRepositoriesPayload struct {
+	Action       string `json:"action"`
+	Installation struct {
+		ID      int64 `json:"id"`
+		Account struct {
+			Login             string `json:"login"`
+			ID                int64  `json:"id"`
+			AvatarURL         string `json:"avatar_url"`
+			GravatarID        string `json:"gravatar_id"`
+			URL               string `json:"url"`
+			HTMLURL           string `json:"html_url"`
+			FollowersURL      string `json:"followers_url"`
+			FollowingURL      string `json:"following_url"`
+			GistsURL          string `json:"gists_url"`
+			StarredURL        string `json:"starred_url"`
+			SubscriptionsURL  string `json:"subscriptions_url"`
+			OrganizationsURL  string `json:"organizations_url"`
+			ReposURL          string `json:"repos_url"`
+			EventsURL         string `json:"events_url"`
+			ReceivedEventsURL string `json:"received_events_url"`
+			Type              string `json:"type"`
+			SiteAdmin         bool   `json:"site_admin"`
+		} `json:"account"`
+		RepositorySelection string `json:"repository_selection"`
+		AccessTokensURL     string `json:"access_tokens_url"`
+		RepositoriesURL     string `json:"repositories_url"`
+		HTMLURL             string `json:"html_url"`
+		AppID               int    `json:"app_id"`
+		TargetID            int    `json:"target_id"`
+		TargetType          string `json:"target_type"`
+		Permissions         struct {
+			Issues              string `json:"issues"`
+			Metadata            string `json:"metadata"`
+			PullRequests        string `json:"pull_requests"`
+			RepositoryProjects  string `json:"repository_projects"`
+			VulnerabilityAlerts string `json:"vulnerability_alerts"`
+			Statuses            string `json:"statuses"`
+			Administration      string `json:"administration"`
+			Deployments         string `json:"deployments"`
+			Contents            string `json:"contents"`
+		} `json:"permissions"`
+		Events         []string `json:"events"`
+		CreatedAt      int64    `json:"created_at"`
+		UpdatedAt      int64    `json:"updated_at"`
+		SingleFileName *string  `json:"single_file_name"`
+	} `json:"installation"`
+	RepositoriesAdded []struct {
+		ID       int64  `json:"id"`
+		Name     string `json:"name"`
+		FullName string `json:"full_name"`
+		Private  bool   `json:"private"`
+	} `json:"repositories_added"`
+	RepositoriesRemoved []struct {
+		ID       int64  `json:"id"`
+		Name     string `json:"name"`
+		FullName string `json:"full_name"`
+		Private  bool   `json:"private"`
+	} `json:"repositories_removed"`
+	Sender struct {
+		Login             string `json:"login"`
+		ID                int64  `json:"id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"sender"`
+}
+
 // IssueCommentPayload contains the information for GitHub's issue_comment hook event
 type IssueCommentPayload struct {
 	Action string `json:"action"`

--- a/testdata/github/installation-repositories.json
+++ b/testdata/github/installation-repositories.json
@@ -1,0 +1,77 @@
+{
+    "action": "removed",
+    "installation": {
+      "id": 2,
+      "account": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "repository_selection": "selected",
+      "access_tokens_url": "https://api.github.com/installations/2/access_tokens",
+      "repositories_url": "https://api.github.com/installation/repositories",
+      "html_url": "https://github.com/settings/installations/2",
+      "app_id": 5725,
+      "target_id": 3880403,
+      "target_type": "User",
+      "permissions": {
+        "metadata": "read",
+        "contents": "read",
+        "issues": "write"
+      },
+      "events": [
+        "push",
+        "pull_request"
+      ],
+      "created_at": 1525109898,
+      "updated_at": 1525109899,
+      "single_file_name": "config.yml"
+    },
+    "repository_selection": "selected",
+    "repositories_added": [
+  
+    ],
+    "repositories_removed": [
+      {
+        "id": 1296269,
+        "name": "Hello-World",
+        "full_name": "octocat/Hello-World",
+        "private": false
+      }
+    ],
+    "sender": {
+      "login": "octocat",
+      "id": 1,
+      "node_id": "MDQ6VXNlcjE=",
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    }
+  }


### PR DESCRIPTION
I've recently been using your type definitions while playing around with the Github Webhooks and I realised the `install_repositories` event was missing. I've added it and updated the tests.