### PR TITLE
Adds support for Bitbucket Server

### DIFF
--- a/bitbucket-server/bitbucketserver.go
+++ b/bitbucket-server/bitbucketserver.go
@@ -1,0 +1,218 @@
+package bitbucketserver
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+var (
+	ErrEventNotSpecifiedToParse  = errors.New("no Event specified to parse")
+	ErrInvalidHTTPMethod         = errors.New("invalid HTTP Method")
+	ErrMissingEventKeyHeader     = errors.New("missing X-Event-Key Header")
+	ErrMissingHubSignatureHeader = errors.New("missing X-Hub-Signature Header")
+	ErrEventNotFound             = errors.New("event not defined to be parsed")
+	ErrParsingPayload            = errors.New("error parsing payload")
+	ErrHMACVerificationFailed    = errors.New("HMAC verification failed")
+)
+
+type Event string
+
+const (
+	RepositoryReferenceChangedEvent Event = "repo:refs_changed"
+	RepositoryModifiedEvent         Event = "repo:modified"
+	RepositoryForkedEvent           Event = "repo:forked"
+	RepositoryCommentAddedEvent     Event = "repo:comment:added"
+	RepositoryCommentEditedEvent    Event = "repo:comment:edited"
+	RepositoryCommentDeletedEvent   Event = "repo:comment:deleted"
+
+	PullRequestOpenedEvent   Event = "pr:opened"
+	PullRequestModifiedEvent Event = "pr:modified"
+	PullRequestMergedEvent   Event = "pr:merged"
+	PullRequestDeclinedEvent Event = "pr:declined"
+	PullRequestDeletedEvent  Event = "pr:deleted"
+
+	PullRequestReviewerUpdatedEvent    Event = "pr:reviewer:updated"
+	PullRequestReviewerApprovedEvent   Event = "pr:reviewer:approved"
+	PullRequestReviewerUnapprovedEvent Event = "pr:reviewer:unapproved"
+	PullRequestReviewerNeedsWorkEvent  Event = "pr:reviewer:needs_work"
+
+	PullRequestCommentAddedEvent   Event = "pr:comment:added"
+	PullRequestCommentEditedEvent  Event = "pr:comment:edited"
+	PullRequestCommentDeletedEvent Event = "pr:comment:deleted"
+
+	DiagnosticsPingEvent Event = "diagnostics:ping"
+)
+
+// Option is a configuration option for the webhook
+type Option func(*Webhook) error
+
+// Options is a namespace var for configuration options
+var Options = WebhookOptions{}
+
+// WebhookOptions is a namespace for configuration option methods
+type WebhookOptions struct{}
+
+// Secret registers the GitHub secret
+func (WebhookOptions) Secret(secret string) Option {
+	return func(hook *Webhook) error {
+		hook.secret = secret
+		return nil
+	}
+}
+
+// Webhook instance contains all methods needed to process events
+type Webhook struct {
+	secret string
+}
+
+// New creates and returns a WebHook instance denoted by the Provider type
+func New(options ...Option) (*Webhook, error) {
+	hook := new(Webhook)
+	for _, opt := range options {
+		if err := opt(hook); err != nil {
+			return nil, errors.New("Error applying Option")
+		}
+	}
+	return hook, nil
+}
+
+func (hook *Webhook) Parse(r *http.Request, events ...Event) (interface{}, error) {
+	defer func() {
+		_, _ = io.Copy(ioutil.Discard, r.Body)
+		_ = r.Body.Close()
+	}()
+
+	if len(events) == 0 {
+		return nil, ErrEventNotSpecifiedToParse
+	}
+
+	if r.Method != http.MethodPost {
+		return nil, ErrInvalidHTTPMethod
+	}
+
+	event := r.Header.Get("X-Event-Key")
+	if event == "" {
+		return nil, ErrMissingEventKeyHeader
+	}
+
+	bitbucketEvent := Event(event)
+
+	var found bool
+	for _, evt := range events {
+		if evt == bitbucketEvent {
+			found = true
+			break
+		}
+	}
+	// event not defined to be parsed
+	if !found {
+		return nil, ErrEventNotFound
+	}
+
+	if bitbucketEvent == DiagnosticsPingEvent {
+		return DiagnosticsPingPayload{}, nil
+	}
+
+	payload, err := ioutil.ReadAll(r.Body)
+	if err != nil || len(payload) == 0 {
+		return nil, ErrParsingPayload
+	}
+
+	if len(hook.secret) > 0 {
+		signature := r.Header.Get("X-Hub-Signature")
+		if len(signature) == 0 {
+			return nil, ErrMissingHubSignatureHeader
+		}
+		mac := hmac.New(sha256.New, []byte(hook.secret))
+		_, _ = mac.Write(payload)
+		expectedMAC := hex.EncodeToString(mac.Sum(nil))
+
+		if !hmac.Equal([]byte(signature[7:]), []byte(expectedMAC)) {
+			return nil, ErrHMACVerificationFailed
+		}
+	}
+
+	switch bitbucketEvent {
+	case RepositoryReferenceChangedEvent:
+		var pl RepositoryReferenceChangedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepositoryModifiedEvent:
+		var pl RepositoryModifiedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepositoryForkedEvent:
+		var pl RepositoryForkedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepositoryCommentAddedEvent:
+		var pl RepositoryCommentAddedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepositoryCommentEditedEvent:
+		var pl RepositoryCommentEditedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepositoryCommentDeletedEvent:
+		var pl RepositoryCommentDeletedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestOpenedEvent:
+		var pl PullRequestOpenedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestModifiedEvent:
+		var pl PullRequestModifiedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestMergedEvent:
+		var pl PullRequestMergedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestDeclinedEvent:
+		var pl PullRequestDeclinedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestDeletedEvent:
+		var pl PullRequestDeletedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestReviewerUpdatedEvent:
+		var pl PullRequestReviewerUpdatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestReviewerApprovedEvent:
+		var pl PullRequestReviewerApprovedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestReviewerUnapprovedEvent:
+		var pl PullRequestReviewerUnapprovedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestReviewerNeedsWorkEvent:
+		var pl PullRequestReviewerNeedsWorkPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestCommentAddedEvent:
+		var pl PullRequestCommentAddedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestCommentEditedEvent:
+		var pl PullRequestCommentEditedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestCommentDeletedEvent:
+		var pl PullRequestCommentDeletedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	default:
+		return nil, fmt.Errorf("unknown event %s", bitbucketEvent)
+	}
+}

--- a/bitbucket-server/bitbucketserver_test.go
+++ b/bitbucket-server/bitbucketserver_test.go
@@ -1,0 +1,319 @@
+package bitbucketserver
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	path = "/webhooks"
+)
+
+var hook *Webhook
+
+func TestMain(m *testing.M) {
+	// setup
+	var err error
+	hook, err = New(Options.Secret("secret"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(m.Run())
+	// teardown
+}
+
+func newServer(handler http.HandlerFunc) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, handler)
+	return httptest.NewServer(mux)
+}
+
+func TestBadRequests(t *testing.T) {
+	assert := require.New(t)
+	tests := []struct {
+		name    string
+		event   Event
+		payload io.Reader
+		headers http.Header
+	}{
+		{
+			name:    "BadNoEventHeader",
+			event:   RepositoryReferenceChangedEvent,
+			payload: bytes.NewBuffer([]byte("{}")),
+			headers: http.Header{},
+		},
+		{
+			name:    "BadSignatureLength",
+			event:   RepositoryReferenceChangedEvent,
+			payload: bytes.NewBuffer([]byte("{}")),
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:refs_changed"},
+				"X-Hub-Signature": []string{""},
+			},
+		},
+		{
+			name:    "BadSignatureMatch",
+			event:   RepositoryReferenceChangedEvent,
+			payload: bytes.NewBuffer([]byte("{}")),
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:refs_changed"},
+				"X-Hub-Signature": []string{"sha256=111"},
+			},
+		},
+		{
+			name:    "UnsubscribedEvent",
+			event:   RepositoryReferenceChangedEvent,
+			payload: bytes.NewBuffer([]byte("{}")),
+			headers: http.Header{
+				"X-Event-Key":     []string{"nonexistent_event"},
+				"X-Hub-Signature": []string{"sha256=111"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		client := &http.Client{}
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var parseError error
+			server := newServer(func(w http.ResponseWriter, r *http.Request) {
+				_, parseError = hook.Parse(r, tc.event)
+			})
+			defer server.Close()
+
+			req, err := http.NewRequest(http.MethodPost, server.URL+path, tc.payload)
+			assert.NoError(err)
+			req.Header = tc.headers
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := client.Do(req)
+
+			assert.NoError(err)
+			assert.Equal(http.StatusOK, resp.StatusCode)
+			assert.Error(parseError)
+		})
+	}
+}
+
+func TestWebhooks(t *testing.T) {
+	assert := require.New(t)
+	tests := []struct {
+		name        string
+		event       Event
+		payloadType interface{}
+		filename    string
+		headers     http.Header
+	}{
+		{
+			name:        "Repository refs updated",
+			event:       RepositoryReferenceChangedEvent,
+			payloadType: RepositoryReferenceChangedPayload{},
+			filename:    "../testdata/bitbucket-server/repo-refs-changed.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:refs_changed"},
+				"X-Hub-Signature": []string{"sha256=8a60f7487d167f55886df87d4077192035d76f76a8e0b3a48fd8ae8cad25f391"},
+			},
+		},
+		{
+			name:        "Repository modified",
+			event:       RepositoryModifiedEvent,
+			payloadType: RepositoryModifiedPayload{},
+			filename:    "../testdata/bitbucket-server/repo-modified.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:modified"},
+				"X-Hub-Signature": []string{"sha256=1511ed69d7697ede1699b0217e17b7d0b492eeccc9a5649d5d30dd84f0e5a89a"},
+			},
+		},
+		{
+			name:        "Repository forked",
+			event:       RepositoryForkedEvent,
+			payloadType: RepositoryForkedPayload{},
+			filename:    "../testdata/bitbucket-server/repo-forked.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:forked"},
+				"X-Hub-Signature": []string{"sha256=d34115023042f9e7ef7020200650e2f34da137e0217708475f9b749ad889a16d"},
+			},
+		},
+		{
+			name:        "Repository commit comment edited",
+			event:       RepositoryCommentEditedEvent,
+			payloadType: RepositoryCommentEditedPayload{},
+			filename:    "../testdata/bitbucket-server/repo-comment-edited.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:comment:edited"},
+				"X-Hub-Signature": []string{"sha256=90a8f4898d8dd7a4ef99e33a7f1d86dd3645f45b2a5b59110493cc4b3062a712"},
+			},
+		},
+		{
+			name:        "Repository commit comment deleted",
+			event:       RepositoryCommentDeletedEvent,
+			payloadType: RepositoryCommentDeletedPayload{},
+			filename:    "../testdata/bitbucket-server/repo-comment-deleted.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:comment:deleted"},
+				"X-Hub-Signature": []string{"sha256=e8b6d3d1581366c9f65949c93149b29ba33252f6afa807432f8f823fb08680e7"},
+			},
+		},
+		{
+			name:        "Repository commit comment added",
+			event:       RepositoryCommentAddedEvent,
+			payloadType: RepositoryCommentAddedPayload{},
+			filename:    "../testdata/bitbucket-server/repo-comment-added.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"repo:comment:added"},
+				"X-Hub-Signature": []string{"sha256=80b121d53ec48bb3f8bed9243ba53be62c8eb7d1ce0395ca87fef1938bf9620e"},
+			},
+		},
+		{
+			name:        "Pull request unapproved",
+			event:       PullRequestReviewerUnapprovedEvent,
+			payloadType: PullRequestReviewerUnapprovedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-reviewer-unapproved.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:reviewer:unapproved"},
+				"X-Hub-Signature": []string{"sha256=9822024378738817dc85c0a41feb9fa4825058d28a9a1ee7065bfacd6a04c7c1"},
+			},
+		},
+		{
+			name:        "Pull request reviewer updated",
+			event:       PullRequestReviewerUpdatedEvent,
+			payloadType: PullRequestReviewerUpdatedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-reviewer-updated.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:reviewer:updated"},
+				"X-Hub-Signature": []string{"sha256=07ca94a0a5c5913819a16ce0414f976023aeb0065fa9d80f990aad7f1d936be5"},
+			},
+		},
+		{
+			name:        "Pull request opened",
+			event:       PullRequestOpenedEvent,
+			payloadType: PullRequestOpenedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-opened.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:opened"},
+				"X-Hub-Signature": []string{"sha256=b82c323978a741aa256c0a6bfa13a8f211e1795bd8ddb2641ced122769f7a7c6"},
+			},
+		},
+		{
+			name:        "Pull request modified",
+			event:       PullRequestModifiedEvent,
+			payloadType: PullRequestModifiedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-modified.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:modified"},
+				"X-Hub-Signature": []string{"sha256=1e307462390ff6f0c59fcdb8eb4b2977058b5cbc502a24a0db385f5331136227"},
+			},
+		},
+		{
+			name:        "Pull request merged",
+			event:       PullRequestMergedEvent,
+			payloadType: PullRequestMergedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-merged.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:merged"},
+				"X-Hub-Signature": []string{"sha256=adbee42ddd6a178b0c1160e89f666b53fb8c76495f782a4e3055e3fbee232704"},
+			},
+		},
+		{
+			name:        "Pull request marked needs work",
+			event:       PullRequestReviewerNeedsWorkEvent,
+			payloadType: PullRequestReviewerNeedsWorkPayload{},
+			filename:    "../testdata/bitbucket-server/pr-reviewer-needs-work.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:reviewer:needs_work"},
+				"X-Hub-Signature": []string{"sha256=3d10aadcede2131674654bb48c10fe904b0b2ed3d3b283bdc5c64dbc4856582d"},
+			},
+		},
+		{
+			name:        "Pull request deleted",
+			event:       PullRequestDeletedEvent,
+			payloadType: PullRequestDeletedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-deleted.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:deleted"},
+				"X-Hub-Signature": []string{"sha256=657c5d9839c0e3c1c95e5ceceacb07f0e372328883dab6e25bb619ee8b19a359"},
+			},
+		},
+		{
+			name:        "Pull request declined",
+			event:       PullRequestDeclinedEvent,
+			payloadType: PullRequestDeclinedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-declined.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:declined"},
+				"X-Hub-Signature": []string{"sha256=e323ab4d057f32475340d03c90aa9ec20cd3a96c15200d75e59f221c14053528"},
+			},
+		},
+		{
+			name:        "Pull request comment edited",
+			event:       PullRequestCommentEditedEvent,
+			payloadType: PullRequestCommentEditedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-comment-edited.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:comment:edited"},
+				"X-Hub-Signature": []string{"sha256=66580d1b02904e470cb48c1333452ea0748aecc3a9806f5a0f949be3a8b0a5ec"},
+			},
+		},
+		{
+			name:        "Pull request comment deleted",
+			event:       PullRequestCommentDeletedEvent,
+			payloadType: PullRequestCommentDeletedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-comment-deleted.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:comment:deleted"},
+				"X-Hub-Signature": []string{"sha256=7c9575a6e9b141e063ef34e5066ebe67c3a5b59241e633d1332d70aba468fd04"},
+			},
+		},
+		{
+			name:        "Pull request comment added",
+			event:       PullRequestReviewerApprovedEvent,
+			payloadType: PullRequestReviewerApprovedPayload{},
+			filename:    "../testdata/bitbucket-server/pr-reviewer-approved.json",
+			headers: http.Header{
+				"X-Event-Key":     []string{"pr:reviewer:approved"},
+				"X-Hub-Signature": []string{"sha256=a8b78d774dea02f234069f724ee6c6a3c5c13fc3a3b856dac0a33d8ed9ec1823"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		client := &http.Client{}
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			payload, err := os.Open(tc.filename)
+			assert.NoError(err)
+			defer func() {
+				_ = payload.Close()
+			}()
+
+			var parseError error
+			var results interface{}
+
+			server := newServer(func(w http.ResponseWriter, r *http.Request) {
+				results, parseError = hook.Parse(r, tc.event)
+			})
+			defer server.Close()
+
+			req, err := http.NewRequest(http.MethodPost, server.URL+path, payload)
+			assert.NoError(err)
+			req.Header = tc.headers
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := client.Do(req)
+			assert.NoError(err)
+			assert.Equal(http.StatusOK, resp.StatusCode)
+			assert.NoError(parseError)
+			assert.Equal(reflect.TypeOf(tc.payloadType), reflect.TypeOf(results))
+		})
+	}
+}

--- a/bitbucket-server/payload.go
+++ b/bitbucket-server/payload.go
@@ -1,0 +1,273 @@
+package bitbucketserver
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type DiagnosticsPingPayload struct{}
+
+type RepositoryReferenceChangedPayload struct {
+	Date       Date               `json:"date"`
+	EventKey   Event              `json:"eventKey"`
+	Actor      User               `json:"actor"`
+	Repository Repository         `json:"repository"`
+	Changes    []RepositoryChange `json:"changes"`
+}
+
+type RepositoryModifiedPayload struct {
+	Date     Date       `json:"date"`
+	EventKey Event      `json:"eventKey"`
+	Actor    User       `json:"actor"`
+	Old      Repository `json:"old"`
+	New      Repository `json:"new"`
+}
+
+type RepositoryForkedPayload struct {
+	Date       Date       `json:"date"`
+	EventKey   Event      `json:"eventKey"`
+	Actor      User       `json:"actor"`
+	Repository Repository `json:"repository"`
+}
+
+type RepositoryCommentAddedPayload struct {
+	Date       Date       `json:"date"`
+	EventKey   Event      `json:"eventKey"`
+	Actor      User       `json:"actor"`
+	Comment    Comment    `json:"comment"`
+	Repository Repository `json:"repository"`
+	Commit     string     `json:"commit"`
+}
+
+type RepositoryCommentEditedPayload struct {
+	Date            Date       `json:"date"`
+	EventKey        Event      `json:"eventKey"`
+	Actor           User       `json:"actor"`
+	Comment         Comment    `json:"comment"`
+	PreviousComment string     `json:"previousComment"`
+	Repository      Repository `json:"repository"`
+	Commit          string     `json:"commit"`
+}
+
+type RepositoryCommentDeletedPayload struct {
+	Date       Date       `json:"date"`
+	EventKey   Event      `json:"eventKey"`
+	Actor      User       `json:"actor"`
+	Comment    Comment    `json:"comment"`
+	Repository Repository `json:"repository"`
+	Commit     string     `json:"commit"`
+}
+
+type PullRequestOpenedPayload struct {
+	Date        Date        `json:"date"`
+	EventKey    Event       `json:"eventKey"`
+	Actor       User        `json:"actor"`
+	PullRequest PullRequest `json:"pullRequest"`
+}
+
+type PullRequestModifiedPayload struct {
+	Date                Date                   `json:"date"`
+	EventKey            Event                  `json:"eventKey"`
+	Actor               User                   `json:"actor"`
+	PullRequest         PullRequest            `json:"pullRequest"`
+	PreviousTitle       string                 `json:"previousTitle"`
+	PreviousDescription string                 `json:"previousDescription"`
+	PreviousTarget      map[string]interface{} `json:"previousTarget"`
+}
+
+type PullRequestMergedPayload struct {
+	Date        Date        `json:"date"`
+	EventKey    Event       `json:"eventKey"`
+	Actor       User        `json:"actor"`
+	PullRequest PullRequest `json:"pullRequest"`
+}
+
+type PullRequestDeclinedPayload struct {
+	Date        Date        `json:"date"`
+	EventKey    Event       `json:"eventKey"`
+	Actor       User        `json:"actor"`
+	PullRequest PullRequest `json:"pullRequest"`
+}
+
+type PullRequestDeletedPayload struct {
+	Date        Date        `json:"date"`
+	EventKey    Event       `json:"eventKey"`
+	Actor       User        `json:"actor"`
+	PullRequest PullRequest `json:"pullRequest"`
+}
+
+type PullRequestReviewerUpdatedPayload struct {
+	Date             Date        `json:"date"`
+	EventKey         Event       `json:"eventKey"`
+	Actor            User        `json:"actor"`
+	PullRequest      PullRequest `json:"pullRequest"`
+	RemovedReviewers []User      `json:"removedReviewers"`
+	AddedReviewers   []User      `json:"addedReviewers"`
+}
+
+type PullRequestReviewerApprovedPayload struct {
+	Date           Date                   `json:"date"`
+	EventKey       Event                  `json:"eventKey"`
+	Actor          User                   `json:"actor"`
+	PullRequest    PullRequest            `json:"pullRequest"`
+	Participant    PullRequestParticipant `json:"participant"`
+	PreviousStatus string                 `json:"previousStatus"`
+}
+
+type PullRequestReviewerUnapprovedPayload struct {
+	Date           Date                   `json:"date"`
+	EventKey       Event                  `json:"eventKey"`
+	Actor          User                   `json:"actor"`
+	PullRequest    PullRequest            `json:"pullRequest"`
+	Participant    PullRequestParticipant `json:"participant"`
+	PreviousStatus string                 `json:"previousStatus"`
+}
+
+type PullRequestReviewerNeedsWorkPayload struct {
+	Date           Date                   `json:"date"`
+	EventKey       Event                  `json:"eventKey"`
+	Actor          User                   `json:"actor"`
+	PullRequest    PullRequest            `json:"pullRequest"`
+	Participant    PullRequestParticipant `json:"participant"`
+	PreviousStatus string                 `json:"previousStatus"`
+}
+
+type PullRequestCommentAddedPayload struct {
+	Date            Date        `json:"date"`
+	EventKey        Event       `json:"eventKey"`
+	Actor           User        `json:"actor"`
+	PullRequest     PullRequest `json:"pullRequest"`
+	Comment         Comment     `json:"comment"`
+	CommentParentId uint64      `json:"commentParentId,omitempty"`
+}
+
+type PullRequestCommentEditedPayload struct {
+	Date            Date        `json:"date"`
+	EventKey        Event       `json:"eventKey"`
+	Actor           User        `json:"actor"`
+	PullRequest     PullRequest `json:"pullRequest"`
+	Comment         Comment     `json:"comment"`
+	CommentParentId string      `json:"commentParentId,omitempty"`
+	PreviousComment string      `json:"previousComment"`
+}
+
+type PullRequestCommentDeletedPayload struct {
+	Date            Date        `json:"date"`
+	EventKey        Event       `json:"eventKey"`
+	Actor           User        `json:"actor"`
+	PullRequest     PullRequest `json:"pullRequest"`
+	Comment         Comment     `json:"comment"`
+	CommentParentId uint64      `json:"commentParentId,omitempty"`
+}
+
+// -----------------------
+
+type User struct {
+	ID           uint64                 `json:"id"`
+	Name         string                 `json:"name"`
+	EmailAddress string                 `json:"emailAddress"`
+	DisplayName  string                 `json:"displayName"`
+	Active       bool                   `json:"active"`
+	Slug         string                 `json:"slug"`
+	Type         string                 `json:"type"`
+	Links        map[string]interface{} `json:"links"`
+}
+
+type Repository struct {
+	ID            uint64                 `json:"id"`
+	Slug          string                 `json:"slug"`
+	Name          string                 `json:"name"`
+	ScmId         string                 `json:"scmId"`
+	State         string                 `json:"state"`
+	StatusMessage string                 `json:"statusMessage"`
+	Forkable      bool                   `json:"forkable"`
+	Origin        *Repository            `json:"origin,omitempty"`
+	Project       Project                `json:"project"`
+	Public        bool                   `json:"public"`
+	Links         map[string]interface{} `json:"links"`
+}
+
+type Project struct {
+	ID     uint64                 `json:"id"`
+	Key    string                 `json:"key"`
+	Name   string                 `json:"name"`
+	Type   string                 `json:"type"`
+	Public *bool                  `json:"public,omitempty"`
+	Owner  User                   `json:"owner"`
+	Links  map[string]interface{} `json:"links"`
+}
+
+type PullRequest struct {
+	ID           uint64                   `json:"id"`
+	Version      uint64                   `json:"version"`
+	Title        string                   `json:"title"`
+	Description  string                   `json:"description,omitempty"`
+	State        string                   `json:"state"`
+	Open         bool                     `json:"open"`
+	Closed       bool                     `json:"closed"`
+	CreatedDate  uint64                   `json:"createdDate"`
+	UpdatedDate  uint64                   `json:"updatedDate,omitempty"`
+	ClosedDate   uint64                   `json:"closedDate,omitempty"`
+	FromRef      RepositoryReference      `json:"fromRef"`
+	ToRef        RepositoryReference      `json:"toRef"`
+	Locked       bool                     `json:"locked"`
+	Author       PullRequestParticipant   `json:"author"`
+	Reviewers    []PullRequestParticipant `json:"reviewers"`
+	Participants []PullRequestParticipant `json:"participants"`
+	Properties   map[string]interface{}   `json:"properties,omitempty"`
+	Links        map[string]interface{}   `json:"links"`
+}
+
+type RepositoryChange struct {
+	Reference   RepositoryReference `json:"ref"`
+	ReferenceId string              `json:"refId"`
+	FromHash    string              `json:"fromHash"`
+	ToHash      string              `json:"toHash"`
+	Type        string              `json:"type"`
+}
+
+type RepositoryReference struct {
+	ID           string     `json:"id"`
+	DisplayId    string     `json:"displayId"`
+	Type         string     `json:"type,omitempty"`
+	LatestCommit string     `json:"latestCommit,omitempty"`
+	Repository   Repository `json:"repository,omitempty"`
+}
+
+type Comment struct {
+	ID                  uint64                   `json:"id"`
+	Properties          map[string]interface{}   `json:"properties,omitempty"`
+	Version             uint64                   `json:"version"`
+	Text                string                   `json:"text"`
+	Author              User                     `json:"author"`
+	CreatedDate         uint64                   `json:"createdDate"`
+	UpdatedDate         uint64                   `json:"updatedDate"`
+	Comments            []map[string]interface{} `json:"comments"`
+	Tasks               []map[string]interface{} `json:"tasks"`
+	PermittedOperations map[string]interface{}   `json:"permittedOperations,omitempty"`
+}
+
+type PullRequestParticipant struct {
+	User               User   `json:"user"`
+	LastReviewedCommit string `json:"lastReviewedCommit,omitempty"`
+	Role               string `json:"role"`
+	Approved           bool   `json:"approved"`
+	Status             string `json:"status"`
+}
+
+type Date time.Time
+
+func (b *Date) UnmarshalJSON(p []byte) error {
+	t, err := time.Parse("2006-01-02T15:04:05Z0700", strings.Replace(string(p), "\"", "", -1))
+	if err != nil {
+		return err
+	}
+	*b = Date(t)
+	return nil
+}
+
+func (b Date) MarshalJSON() ([]byte, error) {
+	stamp := fmt.Sprintf("\"%s\"", time.Time(b).Format("2006-01-02T15:04:05Z0700"))
+	return []byte(stamp), nil
+}

--- a/github/payload.go
+++ b/github/payload.go
@@ -3749,7 +3749,7 @@ type PullRequestReviewCommentPayload struct {
 				Href string `json:"href"`
 			} `json:"pull_request"`
 		} `json:"_links"`
-		InReplyToID int64  `json:"in_reply_to_id"`
+		InReplyToID int64 `json:"in_reply_to_id"`
 	} `json:"comment"`
 	PullRequest struct {
 		URL      string `json:"url"`

--- a/testdata/bitbucket-server/pr-comment-added.json
+++ b/testdata/bitbucket-server/pr-comment-added.json
@@ -1,0 +1,213 @@
+{
+  "eventKey": "pr:comment:added",
+  "date": "2019-03-01T10:08:35+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 2,
+    "version": 20,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1550436762919,
+    "updatedDate": 1551366080055,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "50a8ee1fae3abf75738a85f9039b4b2de4947174",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/2"
+        }
+      ]
+    }
+  },
+  "comment": {
+    "properties": {
+      "repositoryId": 4
+    },
+    "id": 167,
+    "version": 0,
+    "text": "test",
+    "author": {
+      "name": "gopher",
+      "emailAddress": "gopher@foo.bar",
+      "id": 3231,
+      "displayName": "Foo Bar",
+      "active": true,
+      "slug": "gopher",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "createdDate": 1551431315592,
+    "updatedDate": 1551431315592,
+    "comments": [],
+    "tasks": []
+  },
+  "commentParentId": 164
+}

--- a/testdata/bitbucket-server/pr-comment-deleted.json
+++ b/testdata/bitbucket-server/pr-comment-deleted.json
@@ -1,0 +1,210 @@
+{
+  "eventKey": "pr:comment:deleted",
+  "date": "2019-03-01T10:09:09+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 2,
+    "version": 20,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1550436762919,
+    "updatedDate": 1551366080055,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "50a8ee1fae3abf75738a85f9039b4b2de4947174",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/2"
+        }
+      ]
+    }
+  },
+  "comment": {
+    "id": 166,
+    "version": 0,
+    "text": "test",
+    "author": {
+      "name": "gopher",
+      "emailAddress": "gopher@foo.bar",
+      "id": 3231,
+      "displayName": "Foo Bar",
+      "active": true,
+      "slug": "gopher",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "createdDate": 1551431209893,
+    "updatedDate": 1551431209893,
+    "comments": [],
+    "tasks": []
+  },
+  "commentParentId": 165
+}

--- a/testdata/bitbucket-server/pr-comment-edited.json
+++ b/testdata/bitbucket-server/pr-comment-edited.json
@@ -1,0 +1,213 @@
+{
+  "eventKey": "pr:comment:edited",
+  "date": "2019-03-01T10:06:11+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 2,
+    "version": 20,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1550436762919,
+    "updatedDate": 1551366080055,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "50a8ee1fae3abf75738a85f9039b4b2de4947174",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/2"
+        }
+      ]
+    }
+  },
+  "comment": {
+    "properties": {
+      "repositoryId": 4
+    },
+    "id": 165,
+    "version": 3,
+    "text": "yada edit comment",
+    "author": {
+      "name": "gopher",
+      "emailAddress": "gopher@foo.bar",
+      "id": 3231,
+      "displayName": "Foo Bar",
+      "active": true,
+      "slug": "gopher",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "createdDate": 1551430363669,
+    "updatedDate": 1551431171528,
+    "comments": [],
+    "tasks": []
+  },
+  "previousComment": "yada yada yada"
+}

--- a/testdata/bitbucket-server/pr-declined.json
+++ b/testdata/bitbucket-server/pr-declined.json
@@ -1,0 +1,185 @@
+{
+  "eventKey": "pr:declined",
+  "date": "2019-03-01T10:12:35+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 2,
+    "version": 23,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "DECLINED",
+    "open": false,
+    "closed": true,
+    "createdDate": 1550436762919,
+    "updatedDate": 1551431555605,
+    "closedDate": 1551431555605,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "50a8ee1fae3abf75738a85f9039b4b2de4947174",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/2"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/bitbucket-server/pr-deleted.json
+++ b/testdata/bitbucket-server/pr-deleted.json
@@ -1,0 +1,184 @@
+{
+  "eventKey": "pr:deleted",
+  "date": "2019-03-01T10:17:10+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 2,
+    "version": 26,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1550436762919,
+    "updatedDate": 1551431770064,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "50a8ee1fae3abf75738a85f9039b4b2de4947174",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/2"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/bitbucket-server/pr-merged.json
+++ b/testdata/bitbucket-server/pr-merged.json
@@ -1,0 +1,214 @@
+{
+  "eventKey": "pr:merged",
+  "date": "2019-03-01T10:37:14+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 5,
+    "version": 2,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "MERGED",
+    "open": false,
+    "closed": true,
+    "createdDate": 1551432675860,
+    "updatedDate": 1551433034286,
+    "closedDate": 1551433034286,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "cde6c45a4210afe81638aa1f3aa960d633c66a90",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "tux",
+          "emailAddress": "cain.piper@foo.bar",
+          "id": 2125,
+          "displayName": "Cain Piper",
+          "active": true,
+          "slug": "tux",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/tux"
+              }
+            ]
+          }
+        },
+        "lastReviewedCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+        "role": "REVIEWER",
+        "approved": true,
+        "status": "APPROVED"
+      }
+    ],
+    "participants": [],
+    "properties": {
+      "mergeCommit": {
+        "displayId": "cbf26be7bfc",
+        "id": "cbf26be7bfc8394906abbd571498fb8d28888b58"
+      }
+    },
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/5"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/bitbucket-server/pr-modified.json
+++ b/testdata/bitbucket-server/pr-modified.json
@@ -1,0 +1,215 @@
+{
+  "eventKey": "pr:modified",
+  "date": "2019-03-01T10:19:48+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bibucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 3,
+    "version": 1,
+    "title": "Feature/wip",
+    "description": "Update README",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1551431949625,
+    "updatedDate": 1551431988769,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "591f702354b3abf1faaca4d23811620d1b2ac984",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bibucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bibucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bibucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bibucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bibucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bibucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bibucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bibucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bibucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bibucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bibucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "tux",
+          "emailAddress": "cain.piper@foo.bar",
+          "id": 2125,
+          "displayName": "Cain Piper",
+          "active": true,
+          "slug": "tux",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bibucket.local/users/tux"
+              }
+            ]
+          }
+        },
+        "role": "REVIEWER",
+        "approved": false,
+        "status": "UNAPPROVED"
+      }
+    ],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bibucket.local/users/gopher/repos/webhook-test/pull-requests/3"
+        }
+      ]
+    }
+  },
+  "previousTitle": "Feature/wip",
+  "previousDescription": "wip",
+  "previousTarget": {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "type": "BRANCH",
+    "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+    "latestChangeset": "038e7b67735e54f6de8f1c5d533c6751df524f6c"
+  }
+}

--- a/testdata/bitbucket-server/pr-opened.json
+++ b/testdata/bitbucket-server/pr-opened.json
@@ -1,0 +1,206 @@
+{
+  "eventKey": "pr:opened",
+  "date": "2019-03-01T10:31:15+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 5,
+    "version": 0,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1551432675860,
+    "updatedDate": 1551432675860,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "cde6c45a4210afe81638aa1f3aa960d633c66a90",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "tux",
+          "emailAddress": "cain.piper@foo.bar",
+          "id": 2125,
+          "displayName": "Cain Piper",
+          "active": true,
+          "slug": "tux",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/tux"
+              }
+            ]
+          }
+        },
+        "role": "REVIEWER",
+        "approved": false,
+        "status": "UNAPPROVED"
+      }
+    ],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/5"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/bitbucket-server/pr-reviewer-approved.json
+++ b/testdata/bitbucket-server/pr-reviewer-approved.json
@@ -1,0 +1,230 @@
+{
+  "eventKey": "pr:reviewer:approved",
+  "date": "2019-03-01T10:35:38+0100",
+  "actor": {
+    "name": "tux",
+    "emailAddress": "cain.piper@foo.bar",
+    "id": 2125,
+    "displayName": "Cain Piper",
+    "active": true,
+    "slug": "tux",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/tux"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 5,
+    "version": 0,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1551432675860,
+    "updatedDate": 1551432675860,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "cde6c45a4210afe81638aa1f3aa960d633c66a90",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "tux",
+          "emailAddress": "cain.piper@foo.bar",
+          "id": 2125,
+          "displayName": "Cain Piper",
+          "active": true,
+          "slug": "tux",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/tux"
+              }
+            ]
+          }
+        },
+        "lastReviewedCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+        "role": "REVIEWER",
+        "approved": true,
+        "status": "APPROVED"
+      }
+    ],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/5"
+        }
+      ]
+    }
+  },
+  "participant": {
+    "user": {
+      "name": "tux",
+      "emailAddress": "cain.piper@foo.bar",
+      "id": 2125,
+      "displayName": "Cain Piper",
+      "active": true,
+      "slug": "tux",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/tux"
+          }
+        ]
+      }
+    },
+    "lastReviewedCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+    "role": "REVIEWER",
+    "approved": true,
+    "status": "APPROVED"
+  },
+  "previousStatus": "NEEDS_WORK"
+}

--- a/testdata/bitbucket-server/pr-reviewer-needs-work.json
+++ b/testdata/bitbucket-server/pr-reviewer-needs-work.json
@@ -1,0 +1,230 @@
+{
+  "eventKey": "pr:reviewer:needs_work",
+  "date": "2019-03-01T10:34:53+0100",
+  "actor": {
+    "name": "tux",
+    "emailAddress": "cain.piper@foo.bar",
+    "id": 2125,
+    "displayName": "Cain Piper",
+    "active": true,
+    "slug": "tux",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/tux"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 5,
+    "version": 0,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1551432675860,
+    "updatedDate": 1551432675860,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "cde6c45a4210afe81638aa1f3aa960d633c66a90",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "tux",
+          "emailAddress": "cain.piper@foo.bar",
+          "id": 2125,
+          "displayName": "Cain Piper",
+          "active": true,
+          "slug": "tux",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/tux"
+              }
+            ]
+          }
+        },
+        "lastReviewedCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+        "role": "REVIEWER",
+        "approved": false,
+        "status": "NEEDS_WORK"
+      }
+    ],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/5"
+        }
+      ]
+    }
+  },
+  "participant": {
+    "user": {
+      "name": "tux",
+      "emailAddress": "cain.piper@foo.bar",
+      "id": 2125,
+      "displayName": "Cain Piper",
+      "active": true,
+      "slug": "tux",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/tux"
+          }
+        ]
+      }
+    },
+    "lastReviewedCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "NEEDS_WORK"
+  },
+  "previousStatus": "UNAPPROVED"
+}

--- a/testdata/bitbucket-server/pr-reviewer-unapproved.json
+++ b/testdata/bitbucket-server/pr-reviewer-unapproved.json
@@ -1,0 +1,230 @@
+{
+  "eventKey": "pr:reviewer:unapproved",
+  "date": "2019-03-01T10:34:15+0100",
+  "actor": {
+    "name": "tux",
+    "emailAddress": "cain.piper@foo.bar",
+    "id": 2125,
+    "displayName": "Cain Piper",
+    "active": true,
+    "slug": "tux",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/tux"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 5,
+    "version": 0,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1551432675860,
+    "updatedDate": 1551432675860,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "cde6c45a4210afe81638aa1f3aa960d633c66a90",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "tux",
+          "emailAddress": "cain.piper@foo.bar",
+          "id": 2125,
+          "displayName": "Cain Piper",
+          "active": true,
+          "slug": "tux",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/tux"
+              }
+            ]
+          }
+        },
+        "lastReviewedCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+        "role": "REVIEWER",
+        "approved": false,
+        "status": "UNAPPROVED"
+      }
+    ],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/5"
+        }
+      ]
+    }
+  },
+  "participant": {
+    "user": {
+      "name": "tux",
+      "emailAddress": "cain.piper@foo.bar",
+      "id": 2125,
+      "displayName": "Cain Piper",
+      "active": true,
+      "slug": "tux",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/tux"
+          }
+        ]
+      }
+    },
+    "lastReviewedCommit": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+  },
+  "previousStatus": "NEEDS_WORK"
+}

--- a/testdata/bitbucket-server/pr-reviewer-updated.json
+++ b/testdata/bitbucket-server/pr-reviewer-updated.json
@@ -1,0 +1,225 @@
+{
+  "eventKey": "pr:reviewer:updated",
+  "date": "2019-03-01T10:19:48+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 3,
+    "version": 1,
+    "title": "Update README",
+    "description": "yada yada yada",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1551431949625,
+    "updatedDate": 1551431988769,
+    "fromRef": {
+      "id": "refs/heads/feature/wip",
+      "displayId": "feature/wip",
+      "latestCommit": "591f702354b3abf1faaca4d23811620d1b2ac984",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+      "repository": {
+        "slug": "webhook-test",
+        "id": 4,
+        "name": "webhook-test",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "~gopher",
+          "id": 2,
+          "name": "Foo Bar",
+          "type": "PERSONAL",
+          "owner": {
+            "name": "gopher",
+            "emailAddress": "gopher@foo.bar",
+            "id": 3231,
+            "displayName": "Foo Bar",
+            "active": true,
+            "slug": "gopher",
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://server.bitbucket.local/users/gopher"
+                }
+              ]
+            }
+          },
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+              "name": "ssh"
+            },
+            {
+              "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+              "name": "http"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "tux",
+          "emailAddress": "cain.piper@foo.bar",
+          "id": 2125,
+          "displayName": "Cain Piper",
+          "active": true,
+          "slug": "tux",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/tux"
+              }
+            ]
+          }
+        },
+        "role": "REVIEWER",
+        "approved": false,
+        "status": "UNAPPROVED"
+      }
+    ],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/pull-requests/3"
+        }
+      ]
+    }
+  },
+  "addedReviewers": [
+    {
+      "name": "tux",
+      "emailAddress": "cain.piper@foo.bar",
+      "id": 2125,
+      "displayName": "Cain Piper",
+      "active": true,
+      "slug": "tux",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/tux"
+          }
+        ]
+      }
+    }
+  ],
+  "removedReviewers": []
+}

--- a/testdata/bitbucket-server/repo-comment-added.json
+++ b/testdata/bitbucket-server/repo-comment-added.json
@@ -1,0 +1,105 @@
+{
+  "eventKey": "repo:comment:added",
+  "date": "2019-02-28T16:17:06+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "comment": {
+    "properties": {
+      "repositoryId": 4
+    },
+    "id": 146,
+    "version": 0,
+    "text": "test",
+    "author": {
+      "name": "gopher",
+      "emailAddress": "gopher@foo.bar",
+      "id": 3231,
+      "displayName": "Foo Bar",
+      "active": true,
+      "slug": "gopher",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "createdDate": 1551367026162,
+    "updatedDate": 1551367026162,
+    "comments": [],
+    "tasks": []
+  },
+  "repository": {
+    "slug": "webhook-test",
+    "id": 4,
+    "name": "webhook-test",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "~gopher",
+      "id": 2,
+      "name": "Foo Bar",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+          "name": "ssh"
+        },
+        {
+          "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+        }
+      ]
+    }
+  },
+  "commit": "038e7b67735e54f6de8f1c5d533c6751df524f6c"
+}

--- a/testdata/bitbucket-server/repo-comment-deleted.json
+++ b/testdata/bitbucket-server/repo-comment-deleted.json
@@ -1,0 +1,102 @@
+{
+  "eventKey": "repo:comment:deleted",
+  "date": "2019-03-01T09:40:51+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "comment": {
+    "id": 145,
+    "version": 1,
+    "text": "Test commit comment editing comment",
+    "author": {
+      "name": "gopher",
+      "emailAddress": "gopher@foo.bar",
+      "id": 3231,
+      "displayName": "Foo Bar",
+      "active": true,
+      "slug": "gopher",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "createdDate": 1551366857036,
+    "updatedDate": 1551429525155,
+    "comments": [],
+    "tasks": []
+  },
+  "repository": {
+    "slug": "webhook-test",
+    "id": 4,
+    "name": "webhook-test",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "~gopher",
+      "id": 2,
+      "name": "Foo Bar",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+          "name": "ssh"
+        },
+        {
+          "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+        }
+      ]
+    }
+  },
+  "commit": "038e7b67735e54f6de8f1c5d533c6751df524f6c"
+}

--- a/testdata/bitbucket-server/repo-comment-edited.json
+++ b/testdata/bitbucket-server/repo-comment-edited.json
@@ -1,0 +1,106 @@
+{
+  "eventKey": "repo:comment:edited",
+  "date": "2019-03-01T09:38:45+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "gopher@foo.bar",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "comment": {
+    "properties": {
+      "repositoryId": 4
+    },
+    "id": 145,
+    "version": 1,
+    "text": "Test commit comment editing comment",
+    "author": {
+      "name": "gopher",
+      "emailAddress": "gopher@foo.bar",
+      "id": 3231,
+      "displayName": "Foo Bar",
+      "active": true,
+      "slug": "gopher",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "createdDate": 1551366857036,
+    "updatedDate": 1551429525155,
+    "comments": [],
+    "tasks": []
+  },
+  "repository": {
+    "slug": "webhook-test",
+    "id": 4,
+    "name": "webhook-test",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "~gopher",
+      "id": 2,
+      "name": "Foo Bar",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "gopher",
+        "emailAddress": "gopher@foo.bar",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+          "name": "ssh"
+        },
+        {
+          "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+        }
+      ]
+    }
+  },
+  "commit": "038e7b67735e54f6de8f1c5d533c6751df524f6c",
+  "previousComment": "Test commit comment"
+}

--- a/testdata/bitbucket-server/repo-forked.json
+++ b/testdata/bitbucket-server/repo-forked.json
@@ -1,0 +1,132 @@
+{
+  "eventKey": "repo:forked",
+  "date": "2019-02-28T16:12:04+0100",
+  "actor": {
+    "name": "tux",
+    "emailAddress": "cain.piper@foo.bar",
+    "id": 2125,
+    "displayName": "Cain Piper",
+    "active": true,
+    "slug": "tux",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/tux"
+        }
+      ]
+    }
+  },
+  "repository": {
+    "slug": "webhook-test",
+    "id": 124,
+    "name": "webhook-test",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": {
+      "slug": "webhook-test",
+      "id": 4,
+      "name": "webhook-test",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "~gopher",
+        "id": 2,
+        "name": "Foo Bar",
+        "type": "PERSONAL",
+        "owner": {
+          "name": "gopher",
+          "emailAddress": "gopher@foo.bar",
+          "id": 3231,
+          "displayName": "Foo Bar",
+          "active": true,
+          "slug": "gopher",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://server.bitbucket.local/users/gopher"
+              }
+            ]
+          }
+        },
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [
+          {
+            "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+            "name": "ssh"
+          },
+          {
+            "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+            "name": "http"
+          }
+        ],
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+          }
+        ]
+      }
+    },
+    "project": {
+      "key": "~tux",
+      "id": 19,
+      "name": "Cain Piper",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "tux",
+        "emailAddress": "cain.piper@foo.bar",
+        "id": 2125,
+        "displayName": "Cain Piper",
+        "active": true,
+        "slug": "tux",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/tux"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/tux"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@server.bitbucket.local:7999/~tux/webhook-test.git",
+          "name": "ssh"
+        },
+        {
+          "href": "https://server.bitbucket.local/scm/~tux/webhook-test.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/tux/repos/webhook-test/browse"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/bitbucket-server/repo-modified.json
+++ b/testdata/bitbucket-server/repo-modified.json
@@ -1,0 +1,132 @@
+{
+  "eventKey": "repo:modified",
+  "date": "2019-02-28T16:08:46+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "foo@bar.se",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "old": {
+    "slug": "webhook-test-2",
+    "id": 4,
+    "name": "webhook-test-2",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "gopher",
+      "id": 2,
+      "name": "Foo Bar",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "gopher",
+        "emailAddress": "foo@bar.se",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+          "name": "ssh"
+        },
+        {
+          "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test-2/browse"
+        }
+      ]
+    }
+  },
+  "new": {
+    "slug": "webhook-test",
+    "id": 4,
+    "name": "webhook-test",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "gopher",
+      "id": 2,
+      "name": "Foo Bar",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "gopher",
+        "emailAddress": "foo@bar.se",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+          "name": "ssh"
+        },
+        {
+          "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/bitbucket-server/repo-refs-changed.json
+++ b/testdata/bitbucket-server/repo-refs-changed.json
@@ -1,0 +1,89 @@
+{
+  "eventKey": "repo:refs_changed",
+  "date": "2019-03-01T10:37:14+0100",
+  "actor": {
+    "name": "gopher",
+    "emailAddress": "foo@bar.com",
+    "id": 3231,
+    "displayName": "Foo Bar",
+    "active": true,
+    "slug": "gopher",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher"
+        }
+      ]
+    }
+  },
+  "repository": {
+    "slug": "webhook-test",
+    "id": 4,
+    "name": "webhook-test",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "~gopher",
+      "id": 2,
+      "name": "Foo Bar",
+      "type": "PERSONAL",
+      "owner": {
+        "name": "gopher",
+        "emailAddress": "foo@bar.com",
+        "id": 3231,
+        "displayName": "Foo Bar",
+        "active": true,
+        "slug": "gopher",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://server.bitbucket.local/users/gopher"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://server.bitbucket.local/users/gopher"
+          }
+        ]
+      }
+    },
+    "public": false,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@server.bitbucket.local:7999/~gopher/webhook-test.git",
+          "name": "ssh"
+        },
+        {
+          "href": "https://server.bitbucket.local/scm/~gopher/webhook-test.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "https://server.bitbucket.local/users/gopher/repos/webhook-test/browse"
+        }
+      ]
+    }
+  },
+  "changes": [
+    {
+      "ref": {
+        "id": "refs/heads/feature/wip",
+        "displayId": "feature/wip",
+        "type": "BRANCH"
+      },
+      "refId": "refs/heads/feature/wip",
+      "fromHash": "32a0b8a740c2963c6f56bd8baf3dc05683d299e0",
+      "toHash": "0000000000000000000000000000000000000000",
+      "type": "DELETE"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for [Bitbucket Server's native webhooks](https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html).

Fixes #60 #59 