### PR TITLE
Add support for Job Events

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -32,6 +32,7 @@ const (
 	WikiPageEvents           Event = "Wiki Page Hook"
 	PipelineEvents           Event = "Pipeline Hook"
 	BuildEvents              Event = "Build Hook"
+	JobEvents                Event = "Job Hook"
 	SystemHookEvents         Event = "System Hook"
 
 	objectPush         string = "push"
@@ -171,6 +172,10 @@ func eventParsing(gitLabEvent Event, events []Event, payload []byte) (interface{
 		var pl BuildEventPayload
 		err := json.Unmarshal([]byte(payload), &pl)
 		return pl, err
+	case JobEvents:
+		var p1 JobEventPayload
+		err := json.Unmarshal([]byte(payload), &p1)
+		return p1, err
 
 	case SystemHookEvents:
 		var pl SystemHookPayload

--- a/gitlab/gitlab_test.go
+++ b/gitlab/gitlab_test.go
@@ -231,6 +231,15 @@ func TestWebhooks(t *testing.T) {
 				"X-Gitlab-Event": []string{"Build Hook"},
 			},
 		},
+		{
+			name:     "JobEvent",
+			event:    JobEvents,
+			typ:      JobEventPayload{},
+			filename: "../testdata/gitlab/job-event.json",
+			headers: http.Header{
+				"X-Gitlab-Event": []string{"Job Hook"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -148,6 +148,29 @@ type BuildEventPayload struct {
 	Repository        Repository  `json:"repository"`
 }
 
+// JobEventPayload contains the information for GitLab's Job status change
+type JobEventPayload struct {
+	ObjectKind       string      `json:"object_kind"`
+	Ref              string      `json:"ref"`
+	Tag              bool        `json:"tag"`
+	BeforeSHA        string      `json:"before_sha"`
+	SHA              string      `json:"sha"`
+	JobID            int64       `json:"Job_id"`
+	JobName          string      `json:"Job_name"`
+	JobStage         string      `json:"Job_stage"`
+	JobStatus        string      `json:"Job_status"`
+	JobStartedAt     customTime  `json:"Job_started_at"`
+	JobFinishedAt    customTime  `json:"Job_finished_at"`
+	JobDuration      int64       `json:"Job_duration"`
+	Job              bool        `json:"Job"`
+	JobFailureReason string      `json:"job_failure_reason"`
+	ProjectID        int64       `json:"project_id"`
+	ProjectName      string      `json:"project_name"`
+	User             User        `json:"user"`
+	Commit           BuildCommit `json:"commit"`
+	Repository       Repository  `json:"repository"`
+}
+
 // SystemHookPayload contains the ObjectKind to match with real hook events
 type SystemHookPayload struct {
 	ObjectKind string `json:"object_kind"`

--- a/testdata/gitlab/job-event.json
+++ b/testdata/gitlab/job-event.json
@@ -1,0 +1,42 @@
+{
+    "object_kind": "job",
+    "ref": "gitlab-script-trigger",
+    "tag": false,
+    "before_sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
+    "sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
+    "job_id": 1977,
+    "job_name": "test",
+    "job_stage": "test",
+    "job_status": "created",
+    "job_started_at": null,
+    "job_finished_at": null,
+    "job_duration": null,
+    "job_allow_failure": false,
+    "job_failure_reason": "script_failure",
+    "project_id": 380,
+    "project_name": "gitlab-org/gitlab-test",
+    "user": {
+      "id": 3,
+      "name": "User",
+      "email": "user@gitlab.com"
+    },
+    "commit": {
+      "id": 2366,
+      "sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
+      "message": "test\n",
+      "author_name": "User",
+      "author_email": "user@gitlab.com",
+      "status": "created",
+      "duration": null,
+      "started_at": null,
+      "finished_at": null
+    },
+    "repository": {
+      "name": "gitlab_test",
+      "description": "Atque in sunt eos similique dolores voluptatem.",
+      "homepage": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
+      "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
+      "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
+      "visibility_level": 20
+    }
+  }


### PR DESCRIPTION
Closes go-playground/webhooks#70, closes go-playground/webhooks#71