### PR TITLE
Allow parsing non-HTTP payloads (#1)

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -83,11 +83,20 @@ func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error)
 		return nil, ErrParsingPayload
 	}
 
+	return hook.ParsePayload(payload, events...)
+}
+
+// ParsePayload verifies and parses the Build event from a payload, and returns
+// the payload object or an error.
+//
+// Similar to Parse (which uses this method under the hood), this is useful in
+// cases where payloads are not represented as HTTP requests - for example are
+// put on a queue for pull processing.
+func (hook Webhook) ParsePayload(payload []byte, events ...Event) (interface{}, error) {
 	var pl BuildPayload
-	err = json.Unmarshal([]byte(payload), &pl)
-	if err != nil {
+	if err := json.Unmarshal(payload, &pl); err != nil {
 		return nil, ErrParsingPayload
 	}
-	return pl, err
 
+	return pl, nil
 }


### PR DESCRIPTION
Hey there, thanks for working on this! 🙇🙇🙇

I have a use case where webhooks are hitting AWS Gateway and are ultimately pushed to an SQS queue that my application can handle asynchronously. This is useful to separate receiving and processing routines, as well as simplifies development because you no longer have to expose your local server to the Internet.

In order to use your excellent library with this approach, I split out the processing bit from `Parse` methods into `ParsePayload` ones, and made `Parse` methods use those to keep the API the same (and avoid writing extra tests 😂).

Please let me know if I can be of any further assistance and thanks again! 🙇🙇🙇