### PR TITLE
Move node_id field from status to status.commit in StatusEvent

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -5336,8 +5336,8 @@ type StatusPayload struct {
 	Description *string `json:"description"`
 	State       string  `json:"state"`
 	Commit      struct {
-		NodeID string `json:"node_id"`
 		Sha    string `json:"sha"`
+		NodeID string `json:"node_id"`
 		Commit struct {
 			Author struct {
 				Name  string    `json:"name"`

--- a/github/payload.go
+++ b/github/payload.go
@@ -5329,7 +5329,6 @@ type SecurityAdvisoryPayload struct {
 // StatusPayload contains the information for GitHub's status hook event
 type StatusPayload struct {
 	ID          int64   `json:"id"`
-	NodeID      string  `json:"node_id"`
 	Sha         string  `json:"sha"`
 	Name        string  `json:"name"`
 	TargetURL   *string `json:"target_url"`
@@ -5337,6 +5336,7 @@ type StatusPayload struct {
 	Description *string `json:"description"`
 	State       string  `json:"state"`
 	Commit      struct {
+		NodeID string `json:"node_id"`
 		Sha    string `json:"sha"`
 		Commit struct {
 			Author struct {


### PR DESCRIPTION
As per the GitHub [docs](https://developer.github.com/v3/activity/events/types/#statusevent), statusevent does not have a node_id field, while its commit does.

This change is needed so that when receiving a status payload, one can locate the commit it was for easily.