### PR TITLE
Add `Installation` to the `ReleasePayload`

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -5139,6 +5139,9 @@ type ReleasePayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
+	Installation struct {
+		ID int `json:"id"`
+	} `json:"installation"`
 }
 
 // RepositoryPayload contains the information for GitHub's repository hook event


### PR DESCRIPTION
When authenticated as GitHub App, `Installation` entry is included in the `ReleasePayload`.