### PR TITLE
Update current gitlab merge request event payload

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -488,27 +488,11 @@ type Author struct {
 	Email string `json:"email"`
 }
 
-// Changes contains all changes associated with a GitLab issue or MR
-type Changes struct {
-	LabelChanges LabelChanges `json:"labels"`
-}
+// Changes contains all the changes in a MergeRequest
+type Changes map[string]Change
 
-// LabelChanges contains changes in labels assocatiated with a GitLab issue or MR
-type LabelChanges struct {
-	Previous []Label `json:"previous"`
-	Current  []Label `json:"current"`
-}
-
-// Label contains all of the GitLab label information
-type Label struct {
-	ID          int64      `json:"id"`
-	Title       string     `json:"title"`
-	Color       string     `json:"color"`
-	ProjectID   int64      `json:"project_id"`
-	CreatedAt   customTime `json:"created_at"`
-	UpdatedAt   customTime `json:"updated_at"`
-	Template    bool       `json:"template"`
-	Description string     `json:"description"`
-	Type        string     `json:"type"`
-	GroupID     int64      `json:"group_id"`
+// Change is an individual change of a field in a MergeRequest
+type Change struct {
+	Current  interface{}
+	Previous interface{}
 }

--- a/testdata/gitlab/merge-request-event.json
+++ b/testdata/gitlab/merge-request-event.json
@@ -108,8 +108,14 @@
     "group_id": 41
   }],
   "changes": {
-    "updated_by_id": [null, 1],
-    "updated_at": ["2017-09-15 16:50:55 UTC", "2017-09-15 16:52:00 UTC"],
+    "updated_by_id": {
+      "previous": null,
+      "current": 1
+    },
+    "updated_at": {
+      "previous": "2017-09-15 16:50:55 UTC",
+      "current":"2017-09-15 16:52:00 UTC"
+    },
     "labels": {
       "previous": [{
         "id": 206,


### PR DESCRIPTION
Gitlab Merge Request event has been updated at an unknown time.
I have updated the current interface to work with the version we have
now, 12th of November 2019.
I have also updated the testdata with the official event from docs:
https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request-events