### PR TITLE
Added `UserUsername` fields to GitLab push and tag event payloads.

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -67,6 +67,7 @@ type PushEventPayload struct {
 	CheckoutSHA       string     `json:"checkout_sha"`
 	UserID            int64      `json:"user_id"`
 	UserName          string     `json:"user_name"`
+	UserUsername      string     `json:"user_username"`
 	UserEmail         string     `json:"user_email"`
 	UserAvatar        string     `json:"user_avatar"`
 	ProjectID         int64      `json:"project_id"`
@@ -85,6 +86,10 @@ type TagEventPayload struct {
 	CheckoutSHA       string     `json:"checkout_sha"`
 	UserID            int64      `json:"user_id"`
 	UserName          string     `json:"user_name"`
+	// NOTE: Although the `user_username` field is not present in the tag event example
+	// from GitLab's documentation, it exists in tag event payloads:
+	// https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/data_builder/push.rb#L88
+	UserUsername      string     `json:"user_username"`
 	UserAvatar        string     `json:"user_avatar"`
 	ProjectID         int64      `json:"project_id"`
 	Project           Project    `json:"Project"`

--- a/testdata/gitlab/push-event.json
+++ b/testdata/gitlab/push-event.json
@@ -6,6 +6,7 @@
   "checkout_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
   "user_id": 4,
   "user_name": "John Smith",
+  "user_username": "jsmith",
   "user_email": "john@example.com",
   "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
   "project_id": 15,

--- a/testdata/gitlab/tag-event.json
+++ b/testdata/gitlab/tag-event.json
@@ -6,6 +6,7 @@
   "checkout_sha": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
   "user_id": 1,
   "user_name": "John Smith",
+  "user_username": "jsmith",
   "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
   "project_id": 1,
   "project":{


### PR DESCRIPTION
This PR exposes the `user_username` field in push and tag event payloads so we can get the GitLab user account from the payloads.

Fixes #93 