### PR TITLE
Add handling for job hooks with build payloads

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -38,6 +38,7 @@ const (
 	objectPush         string = "push"
 	objectTag          string = "tag_push"
 	objectMergeRequest string = "merge_request"
+	objectBuild        string = "build"
 )
 
 // Option is a configuration option for the webhook
@@ -173,9 +174,15 @@ func eventParsing(gitLabEvent Event, events []Event, payload []byte) (interface{
 		err := json.Unmarshal([]byte(payload), &pl)
 		return pl, err
 	case JobEvents:
-		var p1 JobEventPayload
-		err := json.Unmarshal([]byte(payload), &p1)
-		return p1, err
+		var pl JobEventPayload
+		err := json.Unmarshal([]byte(payload), &pl)
+		if err != nil {
+			return nil, err
+		}
+		if pl.ObjectKind == objectBuild {
+			return eventParsing(BuildEvents, events, payload)
+		}
+		return pl, nil
 
 	case SystemHookEvents:
 		var pl SystemHookPayload

--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -139,7 +139,7 @@ type BuildEventPayload struct {
 	BuildStatus       string      `json:"build_status"`
 	BuildStartedAt    customTime  `json:"build_started_at"`
 	BuildFinishedAt   customTime  `json:"build_finished_at"`
-	BuildDuration     int64       `json:"build_duration"`
+	BuildDuration     float64     `json:"build_duration"`
 	BuildAllowFailure bool        `json:"build_allow_failure"`
 	ProjectID         int64       `json:"project_id"`
 	ProjectName       string      `json:"project_name"`

--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -139,7 +139,7 @@ type BuildEventPayload struct {
 	BuildStatus       string      `json:"build_status"`
 	BuildStartedAt    customTime  `json:"build_started_at"`
 	BuildFinishedAt   customTime  `json:"build_finished_at"`
-	BuildDuration     float64     `json:"build_duration"`
+	BuildDuration     int64       `json:"build_duration"`
 	BuildAllowFailure bool        `json:"build_allow_failure"`
 	ProjectID         int64       `json:"project_id"`
 	ProjectName       string      `json:"project_name"`


### PR DESCRIPTION
I went with a similar approach to system hooks in requiring that both job and build events be requested so the caller has to be aware of this combination.

Fixes #95 