### PR TITLE
FIX: gitlab merge request event assignee payload

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -57,6 +57,7 @@ type MergeRequestEventPayload struct {
 	Project          Project          `json:"project"`
 	Repository       Repository       `json:"repository"`
 	Labels           []Label          `json:"labels"`
+	Assignees        []Assignee       `json:"assignees"`
 }
 
 // PushEventPayload contains the information for GitLab's push event
@@ -449,9 +450,11 @@ type MergeRequest struct {
 
 // Assignee contains all of the GitLab assignee information
 type Assignee struct {
+	ID        int64  `json:"id"`
 	Name      string `json:"name"`
 	Username  string `json:"username"`
 	AvatarURL string `json:"avatar_url"`
+	Email     string `json:"email"`
 }
 
 // StDiff contains all of the GitLab diff information

--- a/testdata/gitlab/merge-request-event.json
+++ b/testdata/gitlab/merge-request-event.json
@@ -136,5 +136,14 @@
         "group_id": 41
       }]
     }
-  }
+  },
+  "assignees": [
+    {
+      "id": 6,
+      "name": "User1",
+      "username": "user1",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon",
+      "email": "user1@gmail.com"
+    }
+  ]
 }


### PR DESCRIPTION
- gitlab updated their MR payload which adds a parent field
for the list of assignees
- this fix update the Assignee struct to add the missing `Email`
and `ID` field
- adds an array of assignees as part of the MR event payload

Closes #101