### PR TITLE
Add missing "private" member to repositories in installation event

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -1470,6 +1470,7 @@ type InstallationPayload struct {
 		NodeID   string `json:"node_id"`
 		Name     string `json:"name"`
 		FullName string `json:"full_name"`
+		Private  bool   `json:"private"`
 	} `json:"repositories"`
 	Sender struct {
 		Login             string `json:"login"`


### PR DESCRIPTION
Event documentation shows an additional Private member not represented in the current schema. See:
https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#installation

From playing with my own app, I found it exists. JSON looks like this:
```json
  "action": "created",
  "installation": {
    "id": 00000000
    ...
  },
  "repositories": [
    {
      "id": 0000000000,
      "private": true
      ...
    }
  ],
  ...
}
```