### PR TITLE
add id and email in gitlab user

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -283,9 +283,11 @@ type Snippet struct {
 
 // User contains all of the GitLab user information
 type User struct {
+	ID        int64  `json:"id"`
 	Name      string `json:"name"`
 	UserName  string `json:"username"`
 	AvatarURL string `json:"avatar_url"`
+	Email     string `json:"email"`
 }
 
 // Project contains all of the GitLab project information


### PR DESCRIPTION
almost all User in [webhook ](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#)have `id` and `email` with exception for Job event