### PR TITLE
Add "Runner" to  BuildEventPayload struct

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -150,6 +150,7 @@ type BuildEventPayload struct {
 	User              User        `json:"user"`
 	Commit            BuildCommit `json:"commit"`
 	Repository        Repository  `json:"repository"`
+	Runner            Runner      `json:"runner"`
 }
 
 // JobEventPayload contains the information for GitLab's Job status change


### PR DESCRIPTION
The structure is missing the required property which is in the json https://github.com/go-playground/webhooks/blob/master/testdata/gitlab/job-event.json#L44