### PR TITLE
Changed date field from int64 to time.Time to fix the parsing error.

### DIFF
--- a/github/github_test.go
+++ b/github/github_test.go
@@ -260,7 +260,7 @@ func TestWebhooks(t *testing.T) {
 			filename: "../testdata/github/integration-installation.json",
 			headers: http.Header{
 				"X-Github-Event":  []string{"integration_installation"},
-				"X-Hub-Signature": []string{"sha1=bb2769f05f1a11af3a1edf8f9fac11bae7402a1e"},
+				"X-Hub-Signature": []string{"sha1=1172601d35bdebac5f3aa7618c9e58eafb404c6f"},
 			},
 		},
 		{
@@ -270,7 +270,7 @@ func TestWebhooks(t *testing.T) {
 			filename: "../testdata/github/integration-installation-repositories.json",
 			headers: http.Header{
 				"X-Github-Event":  []string{"integration_installation_repositories"},
-				"X-Hub-Signature": []string{"sha1=2f00a982574188342c2894eb9d1b1e93434687fb"},
+				"X-Hub-Signature": []string{"sha1=7c38ba703a3c89d00823920a47cd8863df8121d2"},
 			},
 		},
 		{

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -240,7 +240,7 @@ func TestWebhooks(t *testing.T) {
 			filename: "../testdata/github/installation.json",
 			headers: http.Header{
 				"X-Github-Event":  []string{"installation"},
-				"X-Hub-Signature": []string{"sha1=2058cf6cc28570710afbc638e669f5c67305a2db"},
+				"X-Hub-Signature": []string{"sha1=2bcb4ad96133ce2dd6d140fad7a80a2b14407f7f"},
 			},
 		},
 		{
@@ -250,7 +250,7 @@ func TestWebhooks(t *testing.T) {
 			filename: "../testdata/github/installation-repositories.json",
 			headers: http.Header{
 				"X-Github-Event":  []string{"installation_repositories"},
-				"X-Hub-Signature": []string{"sha1=c587fbd9dd169db8ae592b3bcc80b08e2e6f4f45"},
+				"X-Hub-Signature": []string{"sha1=997680ef1e6f4a6b6595f5fa70b82989f505137f"},
 			},
 		},
 		{

--- a/github/payload.go
+++ b/github/payload.go
@@ -1587,10 +1587,10 @@ type InstallationPayload struct {
 			PullRequests       string `json:"pull_requests"`
 			RepositoryProjects string `json:"repository_projects"`
 		} `json:"permissions"`
-		Events         []string `json:"events"`
-		CreatedAt      int64    `json:"created_at"`
-		UpdatedAt      int64    `json:"updated_at"`
-		SingleFileName *string  `json:"single_file_name"`
+		Events         []string  `json:"events"`
+		CreatedAt      time.Time `json:"created_at"`
+		UpdatedAt      time.Time `json:"updated_at"`
+		SingleFileName *string   `json:"single_file_name"`
 	} `json:"installation"`
 	Repositories []struct {
 		ID       int64  `json:"id"`
@@ -1665,10 +1665,10 @@ type InstallationRepositoriesPayload struct {
 			Deployments         string `json:"deployments"`
 			Contents            string `json:"contents"`
 		} `json:"permissions"`
-		Events         []string `json:"events"`
-		CreatedAt      int64    `json:"created_at"`
-		UpdatedAt      int64    `json:"updated_at"`
-		SingleFileName *string  `json:"single_file_name"`
+		Events         []string  `json:"events"`
+		CreatedAt      time.Time `json:"created_at"`
+		UpdatedAt      time.Time `json:"updated_at"`
+		SingleFileName *string   `json:"single_file_name"`
 	} `json:"installation"`
 	RepositoriesAdded []struct {
 		ID       int64  `json:"id"`

--- a/testdata/github/installation-repositories.json
+++ b/testdata/github/installation-repositories.json
@@ -38,8 +38,8 @@
         "push",
         "pull_request"
       ],
-      "created_at": 1525109898,
-      "updated_at": 1525109899,
+      "created_at": "2022-03-02T18:02:51.000Z",
+      "updated_at": "2022-03-02T18:02:51.000Z",
       "single_file_name": "config.yml"
     },
     "repository_selection": "selected",

--- a/testdata/github/installation.json
+++ b/testdata/github/installation.json
@@ -38,8 +38,8 @@
       "push",
       "pull_request"
     ],
-    "created_at": 1525109898,
-    "updated_at": 1525109899,
+    "created_at": "2022-03-02T18:02:51.000Z",
+    "updated_at": "2022-03-02T18:02:51.000Z",
     "single_file_name": "config.yml"
   },
   "repositories": [

--- a/testdata/github/integration-installation-repositories.json
+++ b/testdata/github/integration-installation-repositories.json
@@ -38,8 +38,8 @@
       "push",
       "pull_request"
     ],
-    "created_at": 1525109898,
-    "updated_at": 1525109899,
+    "created_at": "2022-03-02T18:02:51.000Z",
+    "updated_at": "2022-03-02T18:02:51.000Z",
     "single_file_name": "config.yml"
   },
   "repository_selection": "selected",

--- a/testdata/github/integration-installation.json
+++ b/testdata/github/integration-installation.json
@@ -37,8 +37,8 @@
     "events": [
       "pull_request"
     ],
-    "created_at": 1516025475,
-    "updated_at": 1516025475,
+    "created_at": "2022-03-02T18:02:51.000Z",
+    "updated_at": "2022-03-02T18:02:51.000Z",
     "single_file_name": null
   },
   "repositories": [


### PR DESCRIPTION
Related issue: https://github.com/go-playground/webhooks/issues/47

This PR fixes the parse error for installation repositories event for date fields by using time.Time instead of int64 type.