### PR TITLE
Fix GitLab webhook event Project field typo

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -73,7 +73,7 @@ type PushEventPayload struct {
 	UserEmail         string     `json:"user_email"`
 	UserAvatar        string     `json:"user_avatar"`
 	ProjectID         int64      `json:"project_id"`
-	Project           Project    `json:"Project"`
+	Project           Project    `json:"project"`
 	Repository        Repository `json:"repository"`
 	Commits           []Commit   `json:"commits"`
 	TotalCommitsCount int64      `json:"total_commits_count"`
@@ -91,7 +91,7 @@ type TagEventPayload struct {
 	UserUsername      string     `json:"user_username"`
 	UserAvatar        string     `json:"user_avatar"`
 	ProjectID         int64      `json:"project_id"`
-	Project           Project    `json:"Project"`
+	Project           Project    `json:"project"`
 	Repository        Repository `json:"repository"`
 	Commits           []Commit   `json:"commits"`
 	TotalCommitsCount int64      `json:"total_commits_count"`


### PR DESCRIPTION
Fix the json field name of `Project` in GitLab's `PushEventPayload` and `TagEventPayload`. The json field name should be lowercase `project` according to https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#push-events.