### PR TITLE
gitlab issue event sends assignees (multiple) not assignee (single)

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -38,6 +38,7 @@ type IssueEventPayload struct {
 	Repository       Repository       `json:"repository"`
 	ObjectAttributes ObjectAttributes `json:"object_attributes"`
 	Assignee         Assignee         `json:"assignee"`
+	Assignees        []Assignee       `json:"assignees"`
 	Changes          Changes          `json:"changes"`
 }
 

--- a/testdata/gitlab/issue-event.json
+++ b/testdata/gitlab/issue-event.json
@@ -77,5 +77,10 @@
     "name": "User1",
     "username": "user1",
     "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
-  }
+  },
+  "assignees": [{
+    "name": "User1",
+    "username": "user1",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+  }]
 }


### PR DESCRIPTION
I also got hit by the gitlab API change where the IssueEventPayload doesn't contain a field 'assignee' but only 'assignees' - even though there's only one...

https://github.com/go-playground/webhooks/issues/159

The 'assignee' field is deprecated but not removed (https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#issue-events) so it's kept in the struct.