### PR TITLE
Add missing fields to PipelineObjectAttributes

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -685,6 +685,8 @@ type ObjectAttributes struct {
 // PipelineObjectAttributes contains pipeline specific GitLab object attributes information
 type PipelineObjectAttributes struct {
 	ID         int64      `json:"id"`
+	IID        int64      `json:"iid"`
+	Name       string     `json:"name"`
 	Ref        string     `json:"ref"`
 	Tag        bool       `json:"tag"`
 	SHA        string     `json:"sha"`
@@ -696,6 +698,7 @@ type PipelineObjectAttributes struct {
 	FinishedAt customTime `json:"finished_at"`
 	Duration   int64      `json:"duration"`
 	Variables  []Variable `json:"variables"`
+	Url        string     `json:"url"`
 }
 
 // Variable contains pipeline variables

--- a/testdata/gitlab/pipeline-event.json
+++ b/testdata/gitlab/pipeline-event.json
@@ -2,6 +2,8 @@
    "object_kind": "pipeline",
    "object_attributes":{
       "id": 31,
+      "iid": 3,
+      "name": "pipeline_name",
       "ref": "master",
       "tag": false,
       "sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
@@ -21,7 +23,8 @@
           "key": "NESTOR_PROD_ENVIRONMENT",
           "value": "us-west-1"
         }
-      ]
+      ],
+      "url": "http://192.168.64.1:3005/gitlab-org/gitlab-test/-/pipelines/31"
    },
     "merge_request": {
       "id": 1,


### PR DESCRIPTION
Some fields in PipelineObjectAttributes were missing. Reference: https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#pipeline-events

Specifically I am interested in the `IID` field, which is the internal id, and it is the only way to do a GraphQL query for pipelines. It supports only to query by IID.