### PR TITLE
fix: Installation Struct Missing for CommitCommentPayload, IssueCommentPayload and IssuesPayload

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -535,7 +535,7 @@ type CommitCommentPayload struct {
 	} `json:"sender"`
 	Installation struct {
 		ID int64 `json:"id"`
-	} `json:"installation"`
+	} `json:"installation,omitempty"`
 }
 
 // CreatePayload contains the information for GitHub's create hook event
@@ -2122,7 +2122,7 @@ type IssueCommentPayload struct {
 	} `json:"sender"`
 	Installation struct {
 		ID int64 `json:"id"`
-	} `json:"installation"`
+	} `json:"installation,omitempty"`
 }
 
 // IssuesPayload contains the information for GitHub's issues hook event
@@ -2297,7 +2297,7 @@ type IssuesPayload struct {
 	} `json:"sender"`
 	Installation struct {
 		ID int64 `json:"id"`
-	} `json:"installation"`
+	} `json:"installation,omitempty"`
 	Assignee *Assignee `json:"assignee"`
 	Label    *Label    `json:"label"`
 }

--- a/github/payload.go
+++ b/github/payload.go
@@ -187,9 +187,9 @@ type CheckRunPayload struct {
 		Watchers         int64     `json:"watchers"`
 		DefaultBranch    string    `json:"default_branch"`
 	} `json:"repository"`
-	Installation *struct {
+	Installation struct {
 		ID int64 `json:"id"`
-	} `json:"installation"`
+	} `json:"installation,omitempty"`
 	Sender struct {
 		Login             string `json:"login"`
 		ID                int64  `json:"id"`
@@ -362,9 +362,9 @@ type CheckSuitePayload struct {
 		Watchers         int64     `json:"watchers"`
 		DefaultBranch    string    `json:"default_branch"`
 	} `json:"repository"`
-	Installation *struct {
+	Installation struct {
 		ID int64 `json:"id"`
-	} `json:"installation"`
+	} `json:"installation,omitempty"`
 	Sender struct {
 		Login             string `json:"login"`
 		ID                int64  `json:"id"`

--- a/github/payload.go
+++ b/github/payload.go
@@ -533,6 +533,9 @@ type CommitCommentPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
+	Installation struct {
+		ID int64 `json:"id"`
+	} `json:"installation"`
 }
 
 // CreatePayload contains the information for GitHub's create hook event
@@ -2117,6 +2120,9 @@ type IssueCommentPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
+	Installation struct {
+		ID int64 `json:"id"`
+	} `json:"installation"`
 }
 
 // IssuesPayload contains the information for GitHub's issues hook event
@@ -2289,6 +2295,9 @@ type IssuesPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
+	Installation struct {
+		ID int64 `json:"id"`
+	} `json:"installation"`
 	Assignee *Assignee `json:"assignee"`
 	Label    *Label    `json:"label"`
 }

--- a/github/payload.go
+++ b/github/payload.go
@@ -187,9 +187,9 @@ type CheckRunPayload struct {
 		Watchers         int64     `json:"watchers"`
 		DefaultBranch    string    `json:"default_branch"`
 	} `json:"repository"`
-	Installation struct {
+	Installation *struct {
 		ID int64 `json:"id"`
-	} `json:"installation,omitempty"`
+	} `json:"installation"`
 	Sender struct {
 		Login             string `json:"login"`
 		ID                int64  `json:"id"`
@@ -362,9 +362,9 @@ type CheckSuitePayload struct {
 		Watchers         int64     `json:"watchers"`
 		DefaultBranch    string    `json:"default_branch"`
 	} `json:"repository"`
-	Installation struct {
+	Installation *struct {
 		ID int64 `json:"id"`
-	} `json:"installation,omitempty"`
+	} `json:"installation"`
 	Sender struct {
 		Login             string `json:"login"`
 		ID                int64  `json:"id"`
@@ -533,9 +533,9 @@ type CommitCommentPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
-	Installation struct {
+	Installation *struct {
 		ID int64 `json:"id"`
-	} `json:"installation,omitempty"`
+	} `json:"installation"`
 }
 
 // CreatePayload contains the information for GitHub's create hook event
@@ -2120,9 +2120,9 @@ type IssueCommentPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
-	Installation struct {
+	Installation *struct {
 		ID int64 `json:"id"`
-	} `json:"installation,omitempty"`
+	} `json:"installation"`
 }
 
 // IssuesPayload contains the information for GitHub's issues hook event
@@ -2295,9 +2295,9 @@ type IssuesPayload struct {
 		Type              string `json:"type"`
 		SiteAdmin         bool   `json:"site_admin"`
 	} `json:"sender"`
-	Installation struct {
+	Installation *struct {
 		ID int64 `json:"id"`
-	} `json:"installation,omitempty"`
+	} `json:"installation"`
 	Assignee *Assignee `json:"assignee"`
 	Label    *Label    `json:"label"`
 }


### PR DESCRIPTION
This pull request fixes issue https://github.com/go-playground/webhooks/issues/177