### PR TITLE
chore: the gitlab merge request payload is outdated

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -52,6 +52,7 @@ type ConfidentialIssueEventPayload struct {
 // MergeRequestEventPayload contains the information for GitLab's merge request event
 type MergeRequestEventPayload struct {
 	ObjectKind       string           `json:"object_kind"`
+	EventType        string           `json:"event_type"`
 	User             User             `json:"user"`
 	ObjectAttributes ObjectAttributes `json:"object_attributes"`
 	Changes          Changes          `json:"changes"`
@@ -59,6 +60,15 @@ type MergeRequestEventPayload struct {
 	Repository       Repository       `json:"repository"`
 	Labels           []Label          `json:"labels"`
 	Assignees        []Assignee       `json:"assignees"`
+	Reviewers        []Reviewers      `json:"reviewers"`
+}
+
+// Reviewers contains all of the GitLab reviewers information
+type Reviewers struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Username  string `json:"username"`
+	AvatarURL string `json:"avatar_url"`
 }
 
 // PushEventPayload contains the information for GitLab's push event
@@ -605,6 +615,7 @@ type Project struct {
 	VisibilityLevel   int64  `json:"visibility_level"`
 	PathWithNamespace string `json:"path_with_namespace"`
 	DefaultBranch     string `json:"default_branch"`
+	CiConfigPath      string `json:"ci_config_path"`
 	Homepage          string `json:"homepage"`
 	URL               string `json:"url"`
 	SSHURL            string `json:"ssh_url"`
@@ -628,6 +639,7 @@ type ObjectAttributes struct {
 	Title            string     `json:"title"`
 	AssigneeIDS      []int64    `json:"assignee_ids"`
 	AssigneeID       int64      `json:"assignee_id"`
+	ReviewerIDs      []int64    `json:"reviewer_ids"`
 	AuthorID         int64      `json:"author_id"`
 	ProjectID        int64      `json:"project_id"`
 	CreatedAt        customTime `json:"created_at"`
@@ -813,6 +825,7 @@ type Target struct {
 type LastCommit struct {
 	ID        string     `json:"id"`
 	Message   string     `json:"message"`
+	Title     string     `json:"title"`
 	Timestamp customTime `json:"timestamp"`
 	URL       string     `json:"url"`
 	Author    Author     `json:"author"`

--- a/testdata/gitlab/merge-request-event.json
+++ b/testdata/gitlab/merge-request-event.json
@@ -1,9 +1,12 @@
 {
   "object_kind": "merge_request",
+  "event_type": "merge_request",
   "user": {
+    "id": 1,
     "name": "Administrator",
     "username": "root",
-    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon",
+    "email": "admin@example.com"
   },
   "project": {
     "id": 1,
@@ -17,6 +20,7 @@
     "visibility_level":20,
     "path_with_namespace":"gitlabhq/gitlab-test",
     "default_branch":"master",
+    "ci_config_path":"",
     "homepage":"http://example.com/gitlabhq/gitlab-test",
     "url":"http://example.com/gitlabhq/gitlab-test.git",
     "ssh_url":"git@example.com:gitlabhq/gitlab-test.git",
@@ -30,20 +34,34 @@
   },
   "object_attributes": {
     "id": 99,
+    "iid": 1,
     "target_branch": "master",
     "source_branch": "ms-viewport",
     "source_project_id": 14,
     "author_id": 51,
+    "assignee_ids": [6],
     "assignee_id": 6,
+    "reviewer_ids": [6],
     "title": "MS-Viewport",
     "created_at": "2013-12-03T17:23:34Z",
     "updated_at": "2013-12-03T17:23:34Z",
+    "last_edited_at": "2013-12-03T17:23:34Z",
+    "last_edited_by_id": 1,
     "milestone_id": null,
+    "state_id": 1,
     "state": "opened",
+    "blocking_discussions_resolved": true,
+    "work_in_progress": false,
+    "first_contribution": true,
     "merge_status": "unchecked",
     "target_project_id": 14,
-    "iid": 1,
     "description": "",
+    "total_time_spent": 1800,
+    "time_change": 30,
+    "human_total_time_spent": "30m",
+    "human_time_change": "30s",
+    "human_time_estimate": "30m",
+    "url": "http://example.com/diaspora/merge_requests/1",
     "source": {
       "name":"Awesome Project",
       "description":"Aut reprehenderit ut est.",
@@ -79,6 +97,7 @@
     "last_commit": {
       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "message": "fixed readme",
+      "title": "Update file README.md",
       "timestamp": "2012-01-03T23:36:29+02:00",
       "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "author": {
@@ -86,14 +105,20 @@
         "email": "gitlabdev@dv6700.(none)"
       }
     },
-    "work_in_progress": false,
-    "url": "http://example.com/diaspora/merge_requests/1",
+    "labels": [{
+      "id": 206,
+      "title": "API",
+      "color": "#ffffff",
+      "project_id": 14,
+      "created_at": "2013-12-03T17:15:43Z",
+      "updated_at": "2013-12-03T17:15:43Z",
+      "template": false,
+      "description": "API related issues",
+      "type": "ProjectLabel",
+      "group_id": 41
+    }],
     "action": "open",
-    "assignee": {
-      "name": "User1",
-      "username": "user1",
-      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
-    }
+    "detailed_merge_status": "mergeable"
   },
   "labels": [{
     "id": 206,
@@ -108,8 +133,14 @@
     "group_id": 41
   }],
   "changes": {
-    "updated_by_id": [null, 1],
-    "updated_at": ["2017-09-15 16:50:55 UTC", "2017-09-15 16:52:00 UTC"],
+    "updated_by_id": {
+      "previous": null,
+      "current": 1
+    },
+    "updated_at": {
+      "previous": "2017-09-15 16:50:55 UTC",
+      "current":"2017-09-15 16:52:00 UTC"
+    },
     "labels": {
       "previous": [{
         "id": 206,
@@ -135,6 +166,14 @@
         "type": "ProjectLabel",
         "group_id": 41
       }]
+    },
+    "last_edited_at": {
+      "previous": null,
+      "current": "2023-03-15 00:00:10 UTC"
+    },
+    "last_edited_by_id": {
+      "previous": null,
+      "current": 3278533
     }
   },
   "assignees": [
@@ -142,8 +181,15 @@
       "id": 6,
       "name": "User1",
       "username": "user1",
-      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon",
-      "email": "user1@gmail.com"
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+    }
+  ],
+  "reviewers": [
+    {
+      "id": 6,
+      "name": "User1",
+      "username": "user1",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
     }
   ]
 }


### PR DESCRIPTION
updated the structs based on https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events

The reviewer's list needed to be included.