### PR TITLE
Add azure basic auth verification

### DIFF
--- a/azuredevops/azuredevops_test.go
+++ b/azuredevops/azuredevops_test.go
@@ -170,3 +170,16 @@ func TestParseBasicAuth(t *testing.T) {
 		assert.Nil(t, p)
 	}
 }
+
+func TestBasicAuth(t *testing.T) {
+	const user = "user"
+	const pass = "pass123"
+
+	opt := Options.BasicAuth(user, pass)
+	h := &Webhook{}
+	err := opt(h)
+
+	assert.NoError(t, err)
+	assert.Equal(t, h.username, user)
+	assert.Equal(t, h.password, pass)
+}

--- a/azuredevops/azuredevops_test.go
+++ b/azuredevops/azuredevops_test.go
@@ -1,6 +1,9 @@
 package azuredevops
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/assert"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -115,5 +118,55 @@ func TestWebhooks(t *testing.T) {
 			assert.NoError(parseError)
 			assert.Equal(reflect.TypeOf(tc.typ), reflect.TypeOf(results))
 		})
+	}
+}
+
+func TestParseBasicAuth(t *testing.T) {
+	const validUser = "validUser"
+	const validPass = "pass123"
+	tests := []struct {
+		name        string
+		webhookUser string
+		webhookPass string
+		reqUser     string
+		reqPass     string
+		expectedErr error
+	}{
+		{
+			name:        "valid basic auth",
+			webhookUser: validUser,
+			webhookPass: validPass,
+			reqUser:     validUser,
+			reqPass:     validPass,
+			expectedErr: fmt.Errorf("unknown event "), // no event passed, so this is expected
+		},
+		{
+			name:        "no basic auth provided",
+			expectedErr: fmt.Errorf("unknown event "), // no event passed, so this is expected
+		},
+		{
+			name:        "invalid basic auth",
+			webhookUser: validUser,
+			webhookPass: validPass,
+			reqUser:     "fakeUser",
+			reqPass:     "fakePass",
+			expectedErr: ErrBasicAuthVerificationFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		h := Webhook{
+			username: tt.webhookUser,
+			password: tt.webhookPass,
+		}
+		body := []byte(`{}`)
+		r, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer(body))
+		assert.NoError(t, err)
+		r.SetBasicAuth(tt.reqUser, tt.reqPass)
+
+		p, err := h.Parse(r)
+
+		assert.Equal(t, err, tt.expectedErr)
+		assert.Nil(t, p)
 	}
 }


### PR DESCRIPTION
Unlike `GitHub`, `GitLab` or `BitBucket` there is no way of verifying `Azure` webhook requests. 

Azure allows setting basic authentication for webhooks [more info](https://docs.microsoft.com/en-us/azure/devops/service-hooks/services/webhooks?view=azure-devops-2020). This PR uses basic authentication to perform requests validation. Basic auth can be set when creating a `Webhook` with the `New` method just like it is done for the other git providers.

It doesn't perform any validation if the username and password are not provided, which means that it doesn't introduce a breaking change.