### PR TITLE
fix: added `created_at` to WorkflowJobPayload

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -6480,6 +6480,7 @@ type WorkflowJobPayload struct {
 		HTMLURL     string    `json:"html_url"`
 		Status      string    `json:"status"`
 		Conclusion  string    `json:"conclusion"`
+		CreatedAt   time.Time `json:"created_at"`
 		StartedAt   time.Time `json:"started_at"`
 		CompletedAt time.Time `json:"completed_at"`
 		Name        string    `json:"name"`


### PR DESCRIPTION
https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=completed#workflow_job

![CleanShot 2024-06-19 at 19 11 00](https://github.com/go-playground/webhooks/assets/29038315/686a38fa-0d7c-40ce-a39a-cf630153f4be)
