### PR TITLE
[GitHub] fix: add topics to RepositoryPayload

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -5458,6 +5458,7 @@ type PushPayload struct {
 		OpenIssues       int64     `json:"open_issues"`
 		Watchers         int64     `json:"watchers"`
 		DefaultBranch    string    `json:"default_branch"`
+		Topics	         []string    `json:"topics"`
 		Stargazers       int64     `json:"stargazers"`
 		MasterBranch     string    `json:"master_branch"`
 	} `json:"repository"`

--- a/github/payload.go
+++ b/github/payload.go
@@ -5758,6 +5758,7 @@ type RepositoryPayload struct {
 		OpenIssues       int64     `json:"open_issues"`
 		Watchers         int64     `json:"watchers"`
 		DefaultBranch    string    `json:"default_branch"`
+		Topics           []string  `json:"topics"`
 	} `json:"repository"`
 	Organization struct {
 		Login            string `json:"login"`

--- a/github/payload.go
+++ b/github/payload.go
@@ -5462,6 +5462,17 @@ type PushPayload struct {
 		Stargazers       int64     `json:"stargazers"`
 		MasterBranch     string    `json:"master_branch"`
 	} `json:"repository"`
+	Organization struct {
+		Login            string `json:"login"`
+		ID               int64  `json:"id"`
+		NodeID           string `json:"node_id"`
+		URL              string `json:"url"`
+		ReposURL         string `json:"repos_url"`
+		EventsURL        string `json:"events_url"`
+		MembersURL       string `json:"members_url"`
+		PublicMembersURL string `json:"public_members_url"`
+		AvatarURL        string `json:"avatar_url"`
+	} `json:"organization"`
 	Pusher struct {
 		Name  string `json:"name"`
 		Email string `json:"email"`

--- a/github/payload.go
+++ b/github/payload.go
@@ -5659,7 +5659,7 @@ type RepositoryPayload struct {
 			From string `json:"from"`
 		} `json:"homepage,omitempty"`
 		Topics struct {
-			From string `json:"from,omitempty"`
+			From []string `json:"from,omitempty"`
 		} `json:"topics,omitempty"`
 		Repository struct {
 			Name struct {


### PR DESCRIPTION
Adds `topics` to `RepositoryPayload`

Repository object details: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository