### PR TITLE
Extend GitHub changes payload

### DIFF
--- a/github/payload.go
+++ b/github/payload.go
@@ -4019,6 +4019,14 @@ type PullRequestPayload struct {
 		Body *struct {
 			From string `json:"from"`
 		} `json:"body"`
+		Base *struct {
+			Ref *struct {
+				From string `json:"from"`
+			} `json:"ref"`
+			Sha *struct {
+				From string `json:"from"`
+			} `json:"Sha"`
+		} `json:"base"`
 	} `json:"changes"`
 	Assignee          *Assignee `json:"assignee"`
 	RequestedReviewer *Assignee `json:"requested_reviewer"`

--- a/github/payload.go
+++ b/github/payload.go
@@ -4025,7 +4025,7 @@ type PullRequestPayload struct {
 			} `json:"ref"`
 			Sha *struct {
 				From string `json:"from"`
-			} `json:"Sha"`
+			} `json:"sha"`
 		} `json:"base"`
 	} `json:"changes"`
 	Assignee          *Assignee `json:"assignee"`


### PR DESCRIPTION
# Changes 

The PR extends the `changes` field by adding `base`, a value available in the webhook's payload when the base branch in a pull request is changed.