### PR TITLE
Add `draft` field for bitbucket PR events

### DIFF
--- a/bitbucket/payload.go
+++ b/bitbucket/payload.go
@@ -470,6 +470,7 @@ type PullRequest struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	State       string `json:"state"`
+	Draft       bool   `json:"draft`"
 	Author      Owner  `json:"author"`
 	Source      struct {
 		Branch struct {


### PR DESCRIPTION
Similar to github and gitlab PR events, bitbucket also supports the `draft` field in the payload. See https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Pull-request

This adds the `draft` field, and exposes it analogously to github/gitlab as `Draft`.